### PR TITLE
do we really need devel versions? let's check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Authors@R:
              comment = c(ORCID = "0000-0002-4287-4801")),
       person(given = "Indrajeet",
              family = "Patil",
-             role = "ctb",
+             role = "aut",
              email = "patilindrajeet.science@gmail.com",
              comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),
       person(given = "Rudolf",
@@ -37,11 +37,11 @@ License: GPL-3
 URL: https://easystats.github.io/report/
 BugReports: https://github.com/easystats/report/issues
 Imports:
-    bayestestR (>= 0.8.3.1),
+    bayestestR (>= 0.8.2),
     effectsize (>= 0.4.4),
-    insight (>= 0.13.1.1),
-    parameters (>= 0.12.0.1),
-    performance (>= 0.7.0.1),
+    insight (>= 0.13.1),
+    parameters (>= 0.12.0),
+    performance (>= 0.7.0),
     stats,
     tools,
     utils
@@ -60,12 +60,6 @@ Suggests:
     testthat
 VignetteBuilder: 
     knitr
-Remotes: 
-    easystats/bayestestR,
-    easystats/effectsize,
-    easystats/insight,
-    easystats/parameters,
-    easystats/performance
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US


### PR DESCRIPTION
GitHub-actions are repeatedly and unpredictably failing because they can't seem to download `easystats` repos from GitHub, so checking if using CRAN versions is any better