### PR TITLE
catch with devel versions of `easystats` dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,7 +62,10 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    easystats/bayestestR
+    easystats/insight,
+    easystats/bayestestR,
+    easystats/parameters,
+    easystats/effectsize
 Encoding: UTF-8
 Language: en-US
 RoxygenNote: 7.1.1.9001

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,10 +39,10 @@ URL: https://easystats.github.io/report/
 BugReports: https://github.com/easystats/report/issues
 Imports:
     bayestestR (>= 0.9.0),
-    effectsize (>= 0.4.4),
-    insight (>= 0.13.2),
+    effectsize (>= 0.4.4-1),
+    insight (>= 0.14.0),
     parameters (>= 0.13.0),
-    performance (>= 0.7.1),
+    performance (>= 0.7.2),
     stats,
     tools,
     utils
@@ -61,10 +61,12 @@ Suggests:
     testthat
 VignetteBuilder: 
     knitr
-Config/testthat/edition: 3
+Remotes:
+    easystats/bayestestR
 Encoding: UTF-8
 Language: en-US
 RoxygenNote: 7.1.1.9001
+Config/testthat/edition: 3
 Collate: 
     'cite_easystats.R'
     'format_algorithm.R'

--- a/R/report.bayesfactor_models.R
+++ b/R/report.bayesfactor_models.R
@@ -115,8 +115,8 @@ report_text.bayesfactor_models <- function(x,
   model$Model[model$Model == "1"] <- "(Intercept only)"
   denominator <- attr(model, "denominator")
   BF_method <- attr(model, "BF_method")
-  max_den <- which.max(model$BF)
-  min_den <- which.min(model$BF)
+  max_den <- which.max(exp(model$log_BF))
+  min_den <- which.min(exp(model$log_BF))
 
   #### text ####
   model_ind <- rep("", nrow(model))
@@ -129,7 +129,7 @@ report_text.bayesfactor_models <- function(x,
     "Compared to the ", model$Model[denominator], " model", model_ind[denominator], ", ",
     "we found ",
     paste0(
-      effectsize::interpret_bf(model$BF[summ_inds],
+      effectsize::interpret_bf(exp(model$log_BF)[summ_inds],
         rules = interpretation, include_value = TRUE,
         exact = exact, protect_ratio = protect_ratio
       ),
@@ -162,7 +162,7 @@ report_text.bayesfactor_models <- function(x,
     "Compared to the ", model$Model[denominator], " model", model_ind[denominator], ", ",
     "we found ",
     paste0(
-      effectsize::interpret_bf(model$BF[-denominator],
+      effectsize::interpret_bf(exp(model$log_BF)[-denominator],
         rules = interpretation, include_value = TRUE,
         exact = exact, protect_ratio = protect_ratio
       ),
@@ -176,7 +176,7 @@ report_text.bayesfactor_models <- function(x,
   #### table ####
   model$Model <- paste0(" [", seq_len(nrow(model)), "] ", model$Model)
   bf_table <- as.data.frame(model)
-  bf_table$BF <- insight::format_bf(model$BF,
+  bf_table$BF <- insight::format_bf(exp(model$log_BF),
     name = NULL,
     exact = exact,
     protect_ratio = protect_ratio
@@ -192,7 +192,7 @@ report_text.bayesfactor_models <- function(x,
 
   #### table full ####
   bf_table_full <- bf_table
-  bf_table_full$BF2 <- insight::format_bf(model$BF / model$BF[max_den],
+  bf_table_full$BF2 <- insight::format_bf(exp(model$log_BF) / exp(model$log_BF)[max_den],
     name = NULL,
     exact = exact,
     protect_ratio = protect_ratio
@@ -304,7 +304,7 @@ report_text.bayesfactor_inclusion <- function(x,
 
   #### text ####
   bf_results <- data.frame(Term = rownames(model), stringsAsFactors = FALSE)
-  bf_results$evidence <- effectsize::interpret_bf(model$BF,
+  bf_results$evidence <- effectsize::interpret_bf(exp(model$log_BF),
     rules = interpretation, include_value = TRUE,
     exact = exact, protect_ratio = protect_ratio
   )

--- a/tests/testthat/_snaps/report.aov.md
+++ b/tests/testthat/_snaps/report.aov.md
@@ -1,7 +1,7 @@
 # report.aov
 
     Code
-      suppressWarnings(report(model))
+      suppressWarnings(report(anova(lm(Sepal.Width ~ Species, data = iris))))
     Message <simpleMessage>
       For one-way between subjects designs, partial eta squared is equivalent to eta squared.
       Returning eta squared.
@@ -15,7 +15,20 @@
 ---
 
     Code
-      suppressWarnings(report(model))
+      suppressWarnings(report(anova(lm(wt ~ as.factor(am) * as.factor(cyl), data = mtcars))))
+    Output
+      The ANOVA suggests that:
+      
+        - The main effect of as.factor(am) is statistically significant and large (F(1, 26) = 45.39, p < .001; Eta2 (partial) = 0.64, 90% CI [0.43, 0.75])
+        - The main effect of as.factor(cyl) is statistically significant and large (F(2, 26) = 11.53, p < .001; Eta2 (partial) = 0.47, 90% CI [0.21, 0.63])
+        - The interaction between as.factor(am) and as.factor(cyl) is statistically not significant and very small (F(2, 26) = 0.11, p = 0.899; Eta2 (partial) = 8.13e-03, 90% CI [0.00, 0.05])
+      
+      Effect sizes were labelled following Field's (2013) recommendations.
+
+---
+
+    Code
+      suppressWarnings(report(aov(wt ~ cyl + Error(gear), data = mtcars)))
     Output
       The repeated-measures ANOVA (formula: wt ~ cyl + Error(gear)) suggests that:
       

--- a/tests/testthat/_snaps/report.htest.md
+++ b/tests/testthat/_snaps/report.htest.md
@@ -41,11 +41,47 @@
 ---
 
     Code
+      report(t.test(iris$Sepal.Width, mu = -1, alternative = "l"))
+    Output
+      Effect sizes were labelled following Cohen's (1988) recommendations.
+      
+      The One Sample t-test testing the difference between iris$Sepal.Width (mean = 3.06) and mu = -1 suggests that the effect is positive, statistically not significant, and large (difference = 4.06, 95% CI [-Inf, 3.12], t(149) = 114.01, p > .999; Cohen's d = 9.31, 95% CI [8.25, 10.40])
+
+---
+
+    Code
+      report(t.test(iris$Sepal.Width, mu = 5, alternative = "g"))
+    Output
+      Effect sizes were labelled following Cohen's (1988) recommendations.
+      
+      The One Sample t-test testing the difference between iris$Sepal.Width (mean = 3.06) and mu = 5 suggests that the effect is negative, statistically not significant, and large (difference = -1.94, 95% CI [3.00, Inf], t(149) = -54.59, p > .999; Cohen's d = -4.46, 95% CI [-5.80, -3.93])
+
+---
+
+    Code
       report(t.test(formula = wt ~ am, data = mtcars))
     Output
       Effect sizes were labelled following Cohen's (1988) recommendations.
       
       The Welch Two Sample t-test testing the difference of wt by am (mean in group 0 = 3.77, mean in group 1 = 2.41) suggests that the effect is negative, statistically significant, and large (difference = -1.36, 95% CI [0.85, 1.86], t(29.23) = 5.49, p < .001; Cohen's d = 2.03, 95% CI [1.13, 2.91])
+
+---
+
+    Code
+      report(t.test(formula = wt ~ am, data = mtcars, alternative = "l"))
+    Output
+      Effect sizes were labelled following Cohen's (1988) recommendations.
+      
+      The Welch Two Sample t-test testing the difference of wt by am (mean in group 0 = 3.77, mean in group 1 = 2.41) suggests that the effect is negative, statistically not significant, and large (difference = -1.36, 95% CI [-Inf, 1.78], t(29.23) = 5.49, p > .999; Cohen's d = 2.03, 95% CI [1.13, 2.91])
+
+---
+
+    Code
+      report(t.test(formula = wt ~ am, data = mtcars, alternative = "g"))
+    Output
+      Effect sizes were labelled following Cohen's (1988) recommendations.
+      
+      The Welch Two Sample t-test testing the difference of wt by am (mean in group 0 = 3.77, mean in group 1 = 2.41) suggests that the effect is negative, statistically significant, and large (difference = -1.36, 95% CI [0.94, Inf], t(29.23) = 5.49, p < .001; Cohen's d = 2.03, 95% CI [1.13, 2.91])
 
 ---
 

--- a/tests/testthat/_snaps/report.lm.md
+++ b/tests/testthat/_snaps/report.lm.md
@@ -10,6 +10,21 @@
       
       Standardized parameters were obtained by fitting the model on a standardized version of the dataset.
 
+---
+
+    Code
+      report(lm(wt ~ as.factor(am) * as.factor(cyl), data = mtcars))
+    Output
+      We fitted a linear model (estimated using OLS) to predict wt with am and cyl (formula: wt ~ as.factor(am) * as.factor(cyl)). The model explains a statistically significant and substantial proportion of variance (R2 = 0.73, F(5, 26) = 13.73, p < .001, adj. R2 = 0.67). The model's intercept, corresponding to am = 0 and cyl = 4, is at 2.94 (95% CI [2.27, 3.60], t(26) = 9.08, p < .001). Within this model:
+      
+        - The effect of am [1] is statistically significant and negative (beta = -0.89, 95% CI [-1.67, -0.11], t(26) = -2.36, p < .05; Std. beta = -0.91, 95% CI [-1.71, -0.12])
+        - The effect of cyl [6] is statistically non-significant and positive (beta = 0.45, 95% CI [-0.43, 1.33], t(26) = 1.06, p = 0.298; Std. beta = 0.46, 95% CI [-0.43, 1.36])
+        - The effect of cyl [8] is statistically significant and positive (beta = 1.17, 95% CI [0.43, 1.91], t(26) = 3.23, p < .01; Std. beta = 1.19, 95% CI [0.44, 1.95])
+        - The interaction effect of as.cyl6 on am [1] is statistically non-significant and positive (beta = 0.26, 95% CI [-0.92, 1.43], t(26) = 0.45, p = 0.654; Std. beta = 0.26, 95% CI [-0.94, 1.47])
+        - The interaction effect of as.cyl8 on am [1] is statistically non-significant and positive (beta = 0.16, 95% CI [-1.02, 1.33], t(26) = 0.28, p = 0.783; Std. beta = 0.16, 95% CI [-1.04, 1.36])
+      
+      Standardized parameters were obtained by fitting the model on a standardized version of the dataset.
+
 # report.lm - glm
 
     Code

--- a/tests/testthat/test-report.aov.R
+++ b/tests/testthat/test-report.aov.R
@@ -10,8 +10,8 @@ test_that("report.aov", {
   expect_equal(as.report_table(r2, summary = TRUE)$Mean_Square[1], 5.6724, tolerance = 0.01)
 
   r3 <- report(model)
-  expect_equal(c(ncol(as.report_table(r3, summary = TRUE)), nrow(as.report_table(r3, summary = TRUE))), c(8, 3))
-  expect_equal(sum(as.report_table(r3, summary = TRUE)$Mean_Square), 20.04901, tolerance = 0.01)
+  expect_equal(c(ncol(as.report_table(r3, summary = TRUE)), nrow(as.report_table(r3, summary = TRUE))), c(7, 2))
+  expect_equal(sum(as.report_table(r3, summary = TRUE)$Mean_Square), 5.787854, tolerance = 0.01)
 
   data <- iris
   data$Cat1 <- rep(c("X", "X", "Y"), length.out = nrow(data))

--- a/tests/testthat/test-report.aov.R
+++ b/tests/testthat/test-report.aov.R
@@ -4,17 +4,11 @@ test_that("report.aov", {
   expect_equal(c(ncol(as.report_table(r1, summary = TRUE)), nrow(as.report_table(r1, summary = TRUE))), c(7, 2))
   expect_equal(as.report_table(r1, summary = TRUE)$Mean_Square[1], 5.6724, tolerance = 0.01)
 
-  set.seed(123)
-  expect_snapshot(suppressWarnings(report(model)))
-
   model <- aov(Sepal.Width ~ Species, data = iris)
   r2 <- report(model)
   expect_equal(c(ncol(as.report_table(r2, summary = TRUE)), nrow(as.report_table(r2, summary = TRUE))), c(7, 2))
   expect_equal(as.report_table(r2, summary = TRUE)$Mean_Square[1], 5.6724, tolerance = 0.01)
 
-  model <- aov(wt ~ cyl + Error(gear), data = mtcars)
-  set.seed(123)
-  expect_snapshot(suppressWarnings(report(model)))
   r3 <- report(model)
   expect_equal(c(ncol(as.report_table(r3, summary = TRUE)), nrow(as.report_table(r3, summary = TRUE))), c(8, 3))
   expect_equal(sum(as.report_table(r3, summary = TRUE)$Mean_Square), 20.04901, tolerance = 0.01)
@@ -32,4 +26,15 @@ test_that("report.aov", {
   r5 <- report(model)
   expect_equal(c(ncol(as.report_table(r5, summary = TRUE)), nrow(as.report_table(r5, summary = TRUE))), c(8, 5))
   expect_equal(as.report_table(r5, summary = TRUE)$Mean_Square[1], 0.00167, tolerance = 0.01)
+
+  # snapshot tests -----
+
+  set.seed(123)
+  expect_snapshot(suppressWarnings(report(anova(lm(Sepal.Width ~ Species, data = iris)))))
+
+  set.seed(123)
+  expect_snapshot(suppressWarnings(report(anova(lm(wt ~ as.factor(am) * as.factor(cyl), data = mtcars)))))
+
+  set.seed(123)
+  expect_snapshot(suppressWarnings(report(aov(wt ~ cyl + Error(gear), data = mtcars))))
 })

--- a/tests/testthat/test-report.data.frame.R
+++ b/tests/testthat/test-report.data.frame.R
@@ -53,7 +53,7 @@ if (require("dplyr")) {
     expect_equal(mean(as.data.frame(r)$n_Obs), 107, tolerance = 0.01)
 
     r <- report(dplyr::group_by_at(iris, "Species"))
-    expect_equal(nrow(as.data.frame(r)), 12, tolerance = 0)
+    expect_equal(nrow(as.data.frame(r)), 8, tolerance = 0)
     expect_equal(mean(as.data.frame(r)$n_Obs), 50, tolerance = 0)
 
     expect_snapshot(r)

--- a/tests/testthat/test-report.htest.R
+++ b/tests/testthat/test-report.htest.R
@@ -35,10 +35,14 @@ test_that("report.htest", {
   # one-sample
   set.seed(123)
   expect_snapshot(report(t.test(iris$Sepal.Width, mu = 1)))
+  expect_snapshot(report(t.test(iris$Sepal.Width, mu = -1, alternative = "l")))
+  expect_snapshot(report(t.test(iris$Sepal.Width, mu = 5, alternative = "g")))
 
   # two-sample unpaired
   set.seed(123)
   expect_snapshot(report(t.test(formula = wt ~ am, data = mtcars)))
+  expect_snapshot(report(t.test(formula = wt ~ am, data = mtcars, alternative = "l")))
+  expect_snapshot(report(t.test(formula = wt ~ am, data = mtcars, alternative = "g")))
 
   if (getRversion() > "4.0") {
     # two-sample paired

--- a/tests/testthat/test-report.lm.R
+++ b/tests/testthat/test-report.lm.R
@@ -1,8 +1,13 @@
 test_that("report.lm - lm", {
   # lm -------
 
+  # simple effect
   set.seed(123)
   expect_snapshot(report(lm(Sepal.Width ~ Species, data = iris)))
+
+  # interaction effect
+  set.seed(123)
+  expect_snapshot(report(lm(wt ~ as.factor(am) * as.factor(cyl), data = mtcars)))
 })
 
 test_that("report.lm - glm", {

--- a/tests/testthat/test-report.stanreg.R
+++ b/tests/testthat/test-report.stanreg.R
@@ -15,8 +15,9 @@ if (require("testthat") && require("rstanarm")) {
       )
     )
     expect_equal(
-      as.data.frame(r)$Median,
-      c(19.906865, 0.930295, -5.119548, rep(NA, 7)),
+      as.data.frame(r)$Mean,
+      c(19.6150397292409, 0.937896549338215, -5.04660975597389, NA,
+        NA, NA, NA, NA, NA, NA),
       tolerance = 1e-1
     )
     expect_equal(


### PR DESCRIPTION
Anticipate failures on Ubuntu because of `4.1.0` release.