### PR TITLE
add test for ivreg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,6 +47,7 @@ Imports:
     tools,
     utils
 Suggests:
+    AER,
     BayesFactor,
     brms,
     dplyr,

--- a/tests/testthat/_snaps/report.ivreg.md
+++ b/tests/testthat/_snaps/report.ivreg.md
@@ -1,0 +1,14 @@
+# report-survreg
+
+    Code
+      report(ivr)
+    Message <simpleMessage>
+      Formula contains log- or sqrt-terms. See help("standardize") for how such terms are standardized.
+      Formula contains log- or sqrt-terms. See help("standardize") for how such terms are standardized.
+    Output
+      We fitted a linear model to predict packs with income and population (formula: log(packs) ~ income). The model's explanatory power is weak (R2 = 0.11, adj. R2 = 0.10). The model's intercept, corresponding to income = 0, is at 4.71 (95% CI [4.65, 4.77], t(94) = 150.96, p < .001). Within this model:
+      
+        - The effect of income is statistically significant and negative (beta = -4.76e-10, 95% CI [-8.78e-10, -7.36e-11], t(94) = -2.32, p < .05; Std. beta = -0.08, 95% CI [-0.14, -0.01])
+      
+      Standardized parameters were obtained by fitting the model on a standardized version of the dataset.
+

--- a/tests/testthat/test-report.ivreg.R
+++ b/tests/testthat/test-report.ivreg.R
@@ -1,0 +1,15 @@
+if (require("testthat") && require("report") && require("AER")) {
+  test_that("report-survreg", {
+    data("CigarettesSW", package = "AER")
+
+    # model
+    set.seed(123)
+    ivr <-
+      AER::ivreg(
+        formula = log(packs) ~ income | population,
+        data = CigarettesSW
+      )
+
+    expect_snapshot(report(ivr))
+  })
+}


### PR DESCRIPTION
``` r
library(AER)
#> Loading required package: car
#> Loading required package: carData
#> Loading required package: lmtest
#> Loading required package: zoo
#> 
#> Attaching package: 'zoo'
#> The following objects are masked from 'package:base':
#> 
#>     as.Date, as.Date.numeric
#> Loading required package: sandwich
#> Loading required package: survival
data("CigarettesSW", package = "AER")

# model
set.seed(123)
ivr <-
  AER::ivreg(
    formula = log(packs) ~ income | population,
    data = CigarettesSW
  )

parameters::parameters(ivr)
#> # Fixed Effects
#> 
#> Parameter   | Coefficient |       SE |         95% CI |  t(94) |      p
#> -----------------------------------------------------------------------
#> (Intercept) |        4.71 |     0.03 | [ 4.65,  4.77] | 150.96 | < .001
#> income      |   -4.76e-10 | 2.05e-10 | [ 0.00,  0.00] |  -2.32 | 0.023

report::report(ivr)
#> Formula contains log- or sqrt-terms. See help("standardize") for how such terms are standardized.
#> Formula contains log- or sqrt-terms. See help("standardize") for how such terms are standardized.
#> We fitted a linear model to predict packs with income and population (formula: log(packs) ~ income). The model's explanatory power is weak (R2 = 0.11, adj. R2 = 0.10). The model's intercept, corresponding to income = 0, is at 4.71 (95% CI [4.65, 4.77], t(94) = 150.96, p < .001). Within this model:
#> 
#>   - The effect of income is statistically significant and negative (beta = -4.76e-10, 95% CI [-8.78e-10, -7.36e-11], t(94) = -2.32, p < .05; Std. beta = -0.08, 95% CI [-0.14, -0.01])
#> 
#> Standardized parameters were obtained by fitting the model on a standardized version of the dataset.
```

<sup>Created on 2021-05-29 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>