### PR TITLE
Separate sex and gender; report percentages for 3 categories each

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# report 0.3.6
+* Separated sex and gender into different searches/columns
+* Sex is reported % female, % male, % other, % missing if any cases are missing
+* Gender is reported % Women, % Men, % Non-Binary, % missing if any cases are missing
+* Age reports % missing if any cases are missing
+* Tests have been updated to reflect these changes
+* Tests for missing cases have also been updated to test numbers for `NA`, and strings for `""` as `""` is not NA.
+
+
 # report 0.3.5
 
 * Fixed issue with possibly wrong numbers in the `total` column from 

--- a/R/report_participants.R
+++ b/R/report_participants.R
@@ -206,7 +206,7 @@ report_participants <- function(data,
         data[[age]],
         n = FALSE,
         centrality = "mean",
-        missing_percentage = NULL,
+        missing_percentage = TRUE,
         digits = digits,
         ...
       )
@@ -217,7 +217,7 @@ report_participants <- function(data,
 
   text_sex <- if (all(is.na(data[[sex]]))) {
     ""
-  } else {
+  } else if (insight::format_value(length(data[[sex]][tolower(data[[sex]]) %in% c("")]) / nrow(data) * 100) == "0.00") {
     paste0(
       "Sex: ",
       insight::format_value(length(data[[sex]][tolower(data[[sex]]) %in% c("female", "f")]) / nrow(data) * 100, digits = digits),
@@ -226,20 +226,46 @@ report_participants <- function(data,
       "% males, ",
       insight::format_value(100 - length(data[[sex]][tolower(data[[sex]]) %in% c("male", "m", "female", "f")]) / nrow(data) * 100, digits = digits),
       "% other"
+    )
+  }
+  else {
+    paste0(
+      "Sex: ",
+      insight::format_value(length(data[[sex]][tolower(data[[sex]]) %in% c("female", "f")]) / nrow(data) * 100, digits = digits),
+      "% females, ",
+      insight::format_value(length(data[[sex]][tolower(data[[sex]]) %in% c("male", "m")]) / nrow(data) * 100, digits = digits),
+      "% males, ",
+      insight::format_value(100 - length(data[[sex]][tolower(data[[sex]]) %in% c("male", "m", "female", "f")]) / nrow(data) * 100, digits = digits),
+      "% other, ",
+      insight::format_value(length(data[[sex]][tolower(data[[sex]]) %in% c(NA)]) / nrow(data) * 100),
+      "% missing"
       )
   }
 
   text_gender <- if (all(is.na(data[[gender]]))) {
     ""
-  } else {
+  } else if (insight::format_value(length(data[[gender]][tolower(data[[gender]]) %in% c("")]) / nrow(data) * 100) == "0.00") {
     paste0(
       "Gender: ",
-      insight::format_value(length(data[[gender]][tolower(data[[gender]]) %in% c("woman", "w", "f", "female")]) / nrow(data) * 100, digits = digits),
+      insight::format_value(length(data[[gender]][tolower(data[[gender]]) %in% c("woman", "w")]) / nrow(data) * 100, digits = digits),
       "% women, ",
       insight::format_value(length(data[[gender]][tolower(data[[gender]]) %in% c("man", "m")]) / nrow(data) * 100, digits = digits),
       "% men, ",
       insight::format_value(100 - length(data[[gender]][tolower(data[[gender]]) %in% c("woman", "w", "man", "m")]) / nrow(data) * 100),
-      "% non-binary."
+      "% non-binary"
+    )
+    }
+  else {
+    paste0(
+      "Gender: ",
+      insight::format_value(length(data[[gender]][tolower(data[[gender]]) %in% c("woman", "w")]) / nrow(data) * 100, digits = digits),
+      "% women, ",
+      insight::format_value(length(data[[gender]][tolower(data[[gender]]) %in% c("man", "m")]) / nrow(data) * 100, digits = digits),
+      "% men, ",
+      insight::format_value(100 - length(data[[gender]][tolower(data[[gender]]) %in% c("woman", "w", "man", "m")]) / nrow(data) * 100),
+      "% non-binary, ",
+      insight::format_value(length(data[[sex]][tolower(data[[sex]]) %in% c(NA)]) / nrow(data) * 100),
+      "% missing"
     )
   }
 

--- a/tests/testthat/test-report_participants.R
+++ b/tests/testthat/test-report_participants.R
@@ -1,39 +1,58 @@
 test_that("report_participants", {
   data <- data.frame(
     "Age" = c(22, 22, 54, 54, 8, 8),
-    "Sex" = c("F", "F", "M", "M", "F", "F"),
+    "Sex" = c("F", "F", "M", "M", "I", "I"),
+    "Gender" = c("W", "W", "M", "M", "N", "N"),
     "Participant" = c("S1", "S1", "s2", "s2", "s3", "s3")
   )
 
   expect_equal(
     report_participants(data, age = "Age", sex = "Sex", participant = "Participant"),
-    "3 participants (Mean age = 28.0, SD = 23.6, range: [8, 54]; 66.7% females)"
+    "3 participants (Mean age = 28.0, SD = 23.6, range: [8, 54]; Sex: 33.3% females, 33.3% males, 33.3% other; Gender: 33.3% women, 33.3% men, 33.33% non-binary)"
   )
-  expect_equal(nchar(report_participants(data, participant = "Participant", spell_n = TRUE)), 78)
+
+  expect_equal(nchar(report_participants(data, participant = "Participant", spell_n = TRUE)), 160)
   expect_equal(
     report_participants(data, participant = "Participant", spell_n = TRUE),
-    "Three participants (Mean age = 28.0, SD = 23.6, range: [8, 54]; 66.7% females)"
+    "Three participants (Mean age = 28.0, SD = 23.6, range: [8, 54]; Sex: 33.3% females, 33.3% males, 33.3% other; Gender: 33.3% women, 33.3% men, 33.33% non-binary)"
   )
 
   data2 <- data.frame(
     "Age" = c(22, 22, 54, 54, 8, 8),
-    "Sex" = c("F", "F", "M", "O", "F", "O")
+    "Sex" = c("F", "F", "M", "O", "F", "O"),
+    "Gender" = c("W", "W", "M", "O", "W", "O")
   )
 
   expect_equal(
     report_participants(data2),
-    "6 participants (Mean age = 28.0, SD = 21.1, range: [8, 54]; 50.0% females)"
+    "6 participants (Mean age = 28.0, SD = 21.1, range: [8, 54]; Sex: 50.0% females, 16.7% males, 33.3% other; Gender: 50.0% women, 16.7% men, 33.33% non-binary)"
   )
 
   # TO DO : discuss if this is the correct approach to report in case of missing values
 
+  ###### David Feinberg Comments ##########
+  # There was no reporting of missing values for Age, but there was for Sex,
+  # So I reported missing values for Age, Sex, and Gender.
+  # I didn't touch education. There are no tests for education.
+  # I belive these shouldn't be NA's in tests for Sex and Gender,
+  # because NA means not available
+  # but empty strings are available... they exist...
+  # try:
+  # > is.na("")
+  # [1] FALSE
+  # I suggest testing for empty strings as I put below.
+  # NA works for age because that's supposed to be a number. Not sure if it's
+  # going to work in all cases though...
+  ###### David Feinberg Comments ##########
+
   data3 <- data.frame(
-    "Age" = c(22, 22, 54, 54, 8, 8),
-    "Sex" = c("F", "F", NA, NA, NA, NA)
+    "Age" = c(22, 82, NA, NA, NA, NA),
+    "Sex" = c("F", "F", "", "", "", ""),
+    "Gender" = c("W", "W", "", "", "", "")
   )
 
   expect_equal(
     report_participants(data3),
-    "6 participants (Mean age = 28.0, SD = 21.1, range: [8, 54]; 33.3% females)"
+    "6 participants (Mean age = 52.0, SD = 42.4, range: [22, 82], 66.7% missing; Sex: 33.3% females, 0.0% males, 66.7% other, 0.00% missing; Gender: 33.3% women, 0.0% men, 66.67% non-binary, 0.00% missing)"
   )
 })


### PR DESCRIPTION
# Description

This PR aims at updating the Sex category that previously reported only the number of female participants to deal with both Sex and Gender separately, and provide  3 options each: 
Sex: Female/Male/Other;
Gender: Woman/Man/Non-Binary

# Proposed Changes

I added new functions for gender, changed the examples to have a gender category, and a 3rd option in each example.
