### PR TITLE
Improve `report_participants` (fixes #247)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,12 @@ Authors@R:
              family = "Siegel",
              role = "ctb",
              email = "mutlusun@users.noreply.github.com",
-             comment = c(ORCID = "0000-0002-6021-804X")))
+             comment = c(ORCID = "0000-0002-6021-804X")),
+      person(given = "Rémi",
+             family = "Thériault",
+             role = "ctb",
+             email = "remi.theriault@mail.mcgill.ca",
+             comment = c(ORCID = "0000-0003-4315-6788", Twitter = "@rempsyc")))
 Maintainer: Dominique Makowski <dom.makowski@gmail.com>
 Description: The aim of the 'report' package is to bridge the gap between 
     R’s output and the formatted results contained in your manuscript. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,14 @@ BREAKING CHANGES
 
 * The minimum needed R version is now bumped to 3.5.
 
+Minor changes
+
+* `report_participants` improvement (@rempsyc, #260)
+
+    * Now correctly reports NA values as % missing
+
+    * Adds support for country and race demographic information
+
 # report 0.5.1
 
 * Hotfix release to fix failing tests and to unarchive package on CRAN.
@@ -51,14 +59,13 @@ MAJOR CHANGES
 * Reporting participant's sex/gender information has improved (thanks to
   @drfeinberg, #212)
 
-- Separated sex and gender into different searches/columns
+    - Separated sex and gender into different searches/columns
 
-- Sex is reported % female, % male, % other, % missing if any cases are missing
+    - Sex is reported % female, % male, % other, % missing if any cases are missing
 
-- Gender is reported % Women, % Men, % Non-Binary, % missing if any cases are
-  missing
+    - Gender is reported % Women, % Men, % Non-Binary, % missing if any cases are missing
 
-- Age reports % missing if any cases are missing.
+    - Age reports % missing if any cases are missing.
 
 # report 0.4.0
 

--- a/man/report_participants.Rd
+++ b/man/report_participants.Rd
@@ -65,10 +65,9 @@ the participants section.
 library(report)
 data <- data.frame(
   "Age" = c(22, 23, 54, 21, 8, 42),
-  "Sex" = c("Intersex", "F", "M", "M", "M", "F"),
-  "Gender" = c("N", "W", "W", "M", "M", "M")
+  "Sex" = c("Intersex", "F", "M", "M", "NA", NA),
+  "Gender" = c("N", "W", "W", "M", "NA", NA)
 )
-
 report_participants(data, age = "Age", sex = "Sex")
 
 # Years of education (relative to high school graduation)
@@ -84,11 +83,12 @@ data$Education2 <- c(
   "Highschool", "Bachelor", "Bachelor"
 )
 report_participants(data, age = "Age", sex = "Sex", gender = "Gender", education = "Education2")
+
 # Country
 data <- data.frame(
   "Age" = c(22, 23, 54, 21, 8, 42, 18, 32, 24, 27, 45),
   "Sex" = c("Intersex", "F", "F", "M", "M", "M", "F", "F", "F", "F", "F"),
-  "Gender" = c("F", "F", "F", "M", "M", "M", "F", "F", "F", "F", "F"),
+  "Gender" = c("N", "W", "W", "M", "M", "M", "W", "W", "W", "W", "W"),
   "Country" = c("USA", NA, "Canada", "Canada", "India", "Germany",
   "USA", "USA", "USA", "USA", "Canada"))
 report_participants(data)
@@ -103,7 +103,6 @@ data <- data.frame(
   "Gender" = c("N", "W", "W", "M", "M", "M"),
   "Participant" = c("S1", "S1", "s2", "s2", "s3", "s3")
 )
-
 report_participants(data, age = "Age", sex = "Sex", gender = "Gender", participants = "Participant")
 
 # Grouped data

--- a/man/report_participants.Rd
+++ b/man/report_participants.Rd
@@ -10,10 +10,12 @@ report_participants(
   sex = NULL,
   gender = NULL,
   education = NULL,
+  country = NULL,
   participants = NULL,
   group = NULL,
   spell_n = FALSE,
   digits = 1,
+  threshold = 10,
   ...
 )
 }
@@ -28,11 +30,13 @@ you can specify other characters here as well (e.g., \code{"Intersex"}), but
 the function will group all individuals in those groups as \code{"Other"}.}
 
 \item{gender}{The name of the column containing the gender of the
-The classes should be one of \code{c("Man", "M", "Woman", "F", "Non-Binary", "N")}. Note that you can specify other characters here as well
-(e.g., \code{"Gender Fluid"}), but the function will group all individuals in
-those groups as \code{"Non-Binary"}.}
+classes should be one of \verb{c("Man", "M", "Male", Woman", "W", F", "Female", Non-Binary", "N")}. Note that you can specify other characters
+here as well (e.g., \code{"Gender Fluid"}), but the function will group all
+individuals in those groups as \code{"Non-Binary"}.}
 
 \item{education}{The name of the column containing education information.}
+
+\item{country}{The name of the column containing country information.}
 
 \item{participants}{The name of the participants' identifier column (for
 instance in the case of repeated measures).}
@@ -40,10 +44,12 @@ instance in the case of repeated measures).}
 \item{group}{A character vector indicating the name(s) of the column(s) used
 for stratified description.}
 
-\item{spell_n}{Fully spell the sample size (\code{"Three participants"}
+\item{spell_n}{Logical, fully spell the sample size (\code{"Three participants"}
 instead of \code{"3 participants"}).}
 
 \item{digits}{Number of significant digits.}
+
+\item{threshold}{Percentage after which to combine, e.g., countries (default is 10\%, so countries that represent less than 10\% will be combined in the "other" category).}
 
 \item{...}{Arguments passed to or from other methods.}
 }
@@ -78,7 +84,17 @@ data$Education2 <- c(
   "Highschool", "Bachelor", "Bachelor"
 )
 report_participants(data, age = "Age", sex = "Sex", gender = "Gender", education = "Education2")
+# Country
+data <- data.frame(
+  "Age" = c(22, 23, 54, 21, 8, 42, 18, 32, 24, 27, 45),
+  "Sex" = c("Intersex", "F", "F", "M", "M", "M", "F", "F", "F", "F", "F"),
+  "Gender" = c("F", "F", "F", "M", "M", "M", "F", "F", "F", "F", "F"),
+  "Country" = c("USA", NA, "Canada", "Canada", "India", "Germany",
+  "USA", "USA", "USA", "USA", "Canada"))
+report_participants(data)
 
+# Country, control presentation treshold
+report_participants(data, threshold = 5)
 
 # Repeated measures data
 data <- data.frame(

--- a/man/report_participants.Rd
+++ b/man/report_participants.Rd
@@ -11,6 +11,7 @@ report_participants(
   gender = NULL,
   education = NULL,
   country = NULL,
+  race = NULL,
   participants = NULL,
   group = NULL,
   spell_n = FALSE,
@@ -37,6 +38,8 @@ individuals in those groups as \code{"Non-Binary"}.}
 \item{education}{The name of the column containing education information.}
 
 \item{country}{The name of the column containing country information.}
+
+\item{race}{The name of the column containing race/ethnicity information.}
 
 \item{participants}{The name of the participants' identifier column (for
 instance in the case of repeated measures).}
@@ -94,6 +97,18 @@ data <- data.frame(
 report_participants(data)
 
 # Country, control presentation treshold
+report_participants(data, threshold = 5)
+
+# Race/ethnicity
+data <- data.frame(
+  "Age" = c(22, 23, 54, 21, 8, 42, 18, 32, 24, 27, 45),
+  "Sex" = c("Intersex", "F", "F", "M", "M", "M", "F", "F", "F", "F", "F"),
+  "Gender" = c("N", "W", "W", "M", "M", "M", "W", "W", "W", "W", "W"),
+  "Race" = c("Black", NA, "White", "Asian", "Black", "Arab", "Black",
+  "White", "Asian", "Southeast Asian", "Mixed"))
+report_participants(data)
+
+# Race/ethnicity, control presentation treshold
 report_participants(data, threshold = 5)
 
 # Repeated measures data

--- a/tests/testthat/test-report_participants.R
+++ b/tests/testthat/test-report_participants.R
@@ -28,31 +28,38 @@ test_that("report_participants", {
     "6 participants (Mean age = 28.0, SD = 21.1, range: [8, 54]; Sex: 50.0% females, 16.7% males, 33.3% other; Gender: 50.0% women, 16.7% men, 33.33% non-binary)"
   )
 
-  # TO DO : discuss if this is the correct approach to report in case of missing values
-
-  ###### David Feinberg Comments ##########
-  # There was no reporting of missing values for Age, but there was for Sex,
-  # So I reported missing values for Age, Sex, and Gender.
-  # I didn't touch education. There are no tests for education.
-  # I belive these shouldn't be NA's in tests for Sex and Gender,
-  # because NA means not available
-  # but empty strings are available... they exist...
-  # try:
-  # > is.na("")
-  # [1] FALSE
-  # I suggest testing for empty strings as I put below.
-  # NA works for age because that's supposed to be a number. Not sure if it's
-  # going to work in all cases though...
-  ###### David Feinberg Comments ##########
-
   data3 <- data.frame(
     "Age" = c(22, 82, NA, NA, NA, NA),
-    "Sex" = c("F", "F", "", "", "", ""),
-    "Gender" = c("W", "W", "", "", "", "")
+    "Sex" = c("F", "F", "", "", "NA", NA),
+    "Gender" = c("W", "W", "", "", "NA", NA)
   )
 
   expect_equal(
     report_participants(data3),
-    "6 participants (Mean age = 52.0, SD = 42.4, range: [22, 82], 66.7% missing; Sex: 33.3% females, 0.0% males, 66.7% other, 0.00% missing; Gender: 33.3% women, 0.0% men, 66.67% non-binary, 0.00% missing)"
+    "6 participants (Mean age = 52.0, SD = 42.4, range: [22, 82], 66.7% missing; Sex: 33.3% females, 0.0% males, 0.0% other, 66.67% missing; Gender: 33.3% women, 0.0% men, 0.00% non-binary, 66.67% missing)"
   )
+
+  # Add tests for education and country
+  data4 <- data.frame(
+    "Education" = c(0, 8, -3, -5, 3, 5, NA),
+    "Education2" = c("Bachelor", "PhD", "Highschool", "Highschool", "Bachelor", "Bachelor", NA),
+    "Country" = c("USA", "Canada", "Canada", "India", "Germany", "USA", NA)
+  )
+
+  expect_equal(
+    report_participants(data4),
+    "7 participants (Mean education = 1.3, SD = 4.9, range: [-5, 8]; Country: 28.57% Canada, 28.57% USA, 14.29% Germany, 14.29% India, 14.29% missing)"
+  )
+
+  expect_equal(
+    report_participants(data4, education = "Education2"),
+    "7 participants (Education: Bachelor, 42.86%; Highschool, 28.57%; PhD, 14.29%; missing, 14.29%; Country: 28.57% Canada, 28.57% USA, 14.29% Germany, 14.29% India, 14.29% missing)"
+  )
+
+  expect_equal(
+    report_participants(data4, threshold = 15),
+    "7 participants (Mean education = 1.3, SD = 4.9, range: [-5, 8]; Country: 28.57% Canada, 28.57% USA, 42.86% other)"
+  )
+
 })
+

--- a/tests/testthat/test-report_participants.R
+++ b/tests/testthat/test-report_participants.R
@@ -39,26 +39,27 @@ test_that("report_participants", {
     "6 participants (Mean age = 52.0, SD = 42.4, range: [22, 82], 66.7% missing; Sex: 33.3% females, 0.0% males, 0.0% other, 66.67% missing; Gender: 33.3% women, 0.0% men, 0.00% non-binary, 66.67% missing)"
   )
 
-  # Add tests for education and country
+  # Add tests for education, country, race
   data4 <- data.frame(
     "Education" = c(0, 8, -3, -5, 3, 5, NA),
     "Education2" = c("Bachelor", "PhD", "Highschool", "Highschool", "Bachelor", "Bachelor", NA),
-    "Country" = c("USA", "Canada", "Canada", "India", "Germany", "USA", NA)
+    "Country" = c("USA", "Canada", "Canada", "India", "Germany", "USA", NA),
+    "Race" = c("Black", NA, "White", "Asian", "Black", "Black", "White")
   )
 
   expect_equal(
     report_participants(data4),
-    "7 participants (Mean education = 1.3, SD = 4.9, range: [-5, 8]; Country: 28.57% Canada, 28.57% USA, 14.29% Germany, 14.29% India, 14.29% missing)"
+    "7 participants (Mean education = 1.3, SD = 4.9, range: [-5, 8]; Country: 28.57% Canada, 28.57% USA, 14.29% Germany, 14.29% India, 14.29% missing; Race: 42.86% Black, 28.57% White, 14.29% Asian, 14.29% missing)"
   )
 
   expect_equal(
     report_participants(data4, education = "Education2"),
-    "7 participants (Education: Bachelor, 42.86%; Highschool, 28.57%; PhD, 14.29%; missing, 14.29%; Country: 28.57% Canada, 28.57% USA, 14.29% Germany, 14.29% India, 14.29% missing)"
+    "7 participants (Education: Bachelor, 42.86%; Highschool, 28.57%; PhD, 14.29%; missing, 14.29%; Country: 28.57% Canada, 28.57% USA, 14.29% Germany, 14.29% India, 14.29% missing; Race: 42.86% Black, 28.57% White, 14.29% Asian, 14.29% missing)"
   )
 
   expect_equal(
     report_participants(data4, threshold = 15),
-    "7 participants (Mean education = 1.3, SD = 4.9, range: [-5, 8]; Country: 28.57% Canada, 28.57% USA, 42.86% other)"
+    "7 participants (Mean education = 1.3, SD = 4.9, range: [-5, 8]; Country: 28.57% Canada, 28.57% USA, 42.86% other; Race: 42.86% Black, 28.57% White, 28.57% other)"
   )
 
 })


### PR DESCRIPTION
This PR fixes #247 by adding gender choices and correcting some typos. I also took this opportunity to add a parameter for country since earlier in my own analyses I wished it had this feature. There is a convenience threshold parameter to control how many countries should be printed, based on their % representation.

Reprex:

``` r
data <- data.frame(
  "Gender" = c("F", "F", "F", "Male", "M", "M", "Female", "F", "F", "F", "F"),
  "Country" = c("USA", NA, "Canada", "Canada", "India", "Germany",
                "USA", "USA", "USA", "USA", "Canada"))
report::report_participants(data)
#> [1] "11 participants (Gender: 72.7% women, 27.3% men, 0.00% non-binary; 
#> Country: 45.45% USA, 27.27% Canada, 27.27% other)."

# Control presentation treshold
report::report_participants(data, threshold = 5)
#> [1] "11 participants (Gender: 72.7% women, 27.3% men, 0.00% non-binary; 
#> Country: 45.45% USA, 27.27% Canada, 9.09% Germany, 9.09% India, 9.09% NA)."
```
<sup>Created on 2022-07-01 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

As a side note, I observed an existing behaviour (in the current version, not this PR) that I wonder if it's expected: it classes NAs as non-binary, reprex:

``` r
data <- data.frame(
  "Gender" = c("W", NA, NA, NA, NA, NA, NA, NA, NA, NA, NA))
report::report_participants(data)
#> [1] "11 participants (Gender: 9.1% women, 0.0% men, 90.91% non-binary)."
```
<sup>Created on 2022-07-01 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

I've seen something in the code that seemed related `"% missing"`, but I'm not sure it's working as intended (or it's serving a different purpose).

Finally, I was also thinking that reusing the template for country, one could allow user-defined categorical (or even numeric) categories. Would that be something worth implementing?