### PR TITLE
avoid NAs in citations for report(sessionInfo())

### DIFF
--- a/R/format_citation.R
+++ b/R/format_citation.R
@@ -65,7 +65,7 @@ cite_citation <- function(citation) {
 #' @rdname format_citation
 #' @export
 clean_citation <- function(citation) {
-  if ("citation" %in% class(citation)) {
+  if (isTRUE(inherits(citation, "citation"))) {
     citation <- format(citation,
                        style = "text")
   }

--- a/R/format_citation.R
+++ b/R/format_citation.R
@@ -66,7 +66,8 @@ cite_citation <- function(citation) {
 #' @export
 clean_citation <- function(citation) {
   if ("citation" %in% class(citation)) {
-    citation <- format(citation)[2]
+    citation <- format(citation,
+                       style = "text")
   }
   citation <- unlist(strsplit(citation, "\n"))
   citation <- paste(citation, collapse = "SPLIT")


### PR DESCRIPTION
As proposed by @JauntyJJS in issue #243

Change citation formatting for sessionInfo() to avoid NAs, for example when the tidyverse is attached.
