### PR TITLE
Fix duplicated text

### DIFF
--- a/R/report.lm.R
+++ b/R/report.lm.R
@@ -421,7 +421,7 @@ report_model.lm <- function(x, table = NULL, ...) {
     to_predict_text <- paste0(
       to_predict_text,
       " with ",
-      insight::find_predictors(x, effects = "fixed", flatten = TRUE)
+      paste(insight::find_predictors(x, effects = "fixed", flatten = TRUE), collapse = ", ")
     )
   }
 
@@ -516,10 +516,10 @@ report_text.lm <- function(x, table = NULL, ...) {
   params <- report_parameters(x, table = table, include_intercept = FALSE, ...)
   table <- attributes(params)$table
 
-  info <- report_info(x, effectsize = attributes(params)$effectsize, parameters = params, ...)
-  model <- report_model(x, table = table, ...)
-  perf <- report_performance(x, table = table, ...)
-  intercept <- report_intercept(x, table = table, ...)
+  info <- report_info(x, effectsize = attributes(params)$effectsize, parameters = params)
+  model <- report_model(x, table = table)
+  perf <- report_performance(x, table = table)
+  intercept <- report_intercept(x, table = table)
 
 
   text_full <- paste0(
@@ -543,7 +543,7 @@ report_text.lm <- function(x, table = NULL, ...) {
     ". ",
     summary(intercept),
     " Within this model:\n\n",
-    as.character(summary(params), ...)
+    as.character(summary(params))
   )
 
 

--- a/R/report.lm.R
+++ b/R/report.lm.R
@@ -516,10 +516,10 @@ report_text.lm <- function(x, table = NULL, ...) {
   params <- report_parameters(x, table = table, include_intercept = FALSE, ...)
   table <- attributes(params)$table
 
-  info <- report_info(x, effectsize = attributes(params)$effectsize, parameters = params)
-  model <- report_model(x, table = table)
-  perf <- report_performance(x, table = table)
-  intercept <- report_intercept(x, table = table)
+  info <- report_info(x, effectsize = attributes(params)$effectsize, parameters = params, ...)
+  model <- report_model(x, table = table, ...)
+  perf <- report_performance(x, table = table, ...)
+  intercept <- report_intercept(x, table = table, ...)
 
 
   text_full <- paste0(
@@ -543,7 +543,7 @@ report_text.lm <- function(x, table = NULL, ...) {
     ". ",
     summary(intercept),
     " Within this model:\n\n",
-    as.character(summary(params))
+    as.character(summary(params), ...)
   )
 
 

--- a/R/report_intercept.R
+++ b/R/report_intercept.R
@@ -91,7 +91,7 @@ print.report_intercept <- function(x, ...) {
       text <- c(text, paste0(col, " = [?]"))
     }
   }
-  paste0(", corresponding to ", text, ",")
+  paste0(", corresponding to ", paste(text, collapse = ", "), ",")
 }
 
 

--- a/tests/testthat/_snaps/windows/report.htest-t-test.md
+++ b/tests/testthat/_snaps/windows/report.htest-t-test.md
@@ -85,10 +85,10 @@
     Output
       Effect sizes were labelled following Cohen's (1988) recommendations.
       
-      The Paired t-test testing the difference between x and y (mean of the
-      differences = 0.43) suggests that the effect is positive, statistically
-      significant, and large (difference = 0.43, 95% CI [0.10, 0.76], t(8) = 3.04, p
-      = 0.016; Cohen's d = 1.07, 95% CI [0.19, 1.92])
+      The Paired t-test testing the difference between x and y (mean difference =
+      0.43) suggests that the effect is positive, statistically significant, and
+      large (difference = 0.43, 95% CI [0.10, 0.76], t(8) = 3.04, p = 0.016; Cohen's
+      d = 1.07, 95% CI [0.19, 1.92])
 
 ---
 
@@ -99,10 +99,10 @@
     Output
       Effect sizes were labelled following Cohen's (1988) recommendations.
       
-      The Paired t-test testing the difference between x and y (mean of the
-      differences = 0.43) suggests that the effect is positive, statistically not
-      significant, and large (difference = 0.43, 95% CI [-Inf, 0.70], t(8) = 3.04, p
-      = 0.992; Cohen's d = 1.07, 95% CI [-Inf, 1.77])
+      The Paired t-test testing the difference between x and y (mean difference =
+      0.43) suggests that the effect is positive, statistically not significant, and
+      large (difference = 0.43, 95% CI [-Inf, 0.70], t(8) = 3.04, p = 0.992; Cohen's
+      d = 1.07, 95% CI [-Inf, 1.77])
 
 ---
 
@@ -113,10 +113,10 @@
     Output
       Effect sizes were labelled following Cohen's (1988) recommendations.
       
-      The Paired t-test testing the difference between x and y (mean of the
-      differences = 0.43) suggests that the effect is positive, statistically
-      significant, and large (difference = 0.43, 95% CI [0.17, Inf], t(8) = 3.04, p =
-      0.008; Cohen's d = 1.07, 95% CI [0.32, Inf])
+      The Paired t-test testing the difference between x and y (mean difference =
+      0.43) suggests that the effect is positive, statistically significant, and
+      large (difference = 0.43, 95% CI [0.17, Inf], t(8) = 3.04, p = 0.008; Cohen's d
+      = 1.07, 95% CI [0.32, Inf])
 
 ---
 
@@ -128,7 +128,7 @@
       Effect sizes were labelled following Cohen's (1988) recommendations.
       
       The Paired t-test testing the difference between Pair(extra.1, extra.2) (mean
-      of the differences = -1.58) suggests that the effect is negative, statistically
+      difference = -1.58) suggests that the effect is negative, statistically
       significant, and large (difference = -1.58, 95% CI [-2.46, -0.70], t(9) =
       -4.06, p = 0.003; Cohen's d = -1.35, 95% CI [-2.23, -0.44])
 

--- a/tests/testthat/_snaps/windows/report.ivreg.md
+++ b/tests/testthat/_snaps/windows/report.ivreg.md
@@ -8,40 +8,11 @@
       Formula contains log- or sqrt-terms. See help("standardize") for how
         such terms are standardized.
     Output
-      We fitted a linear model to predict packs with rprice (formula: log(packs) ~
-      log(rprice) + log(rincome)). The model's explanatory power is substantial (R2 =
-      0.42, adj. R2 = 0.39). The model's intercept, corresponding to rprice = 0, is
-      at 9.43 (95% CI [6.69, 12.17], t(45) = 6.94, p < .001). Within this model:
-      
-        - The effect of rprice [log] is statistically significant and negative (beta =
-      -1.14, 95% CI [-1.87, -0.42], t(45) = -3.18, p = 0.003; Std. beta = -0.53, 95%
-      CI [-0.86, -0.20])
-        - The effect of rincome [log] is statistically non-significant and positive
-      (beta = 0.21, 95% CI [-0.33, 0.76], t(45) = 0.80, p = 0.429; Std. beta = 0.12,
-      95% CI [-0.14, 0.39])
-      
-      Standardized parameters were obtained by fitting the model on a standardized
-      version of the dataset. 95% Confidence Intervals (CIs) and p-values were
-      computed using a Wald t-distribution approximation., We fitted a linear model
-      to predict packs with rincome (formula: log(packs) ~ log(rprice) +
-      log(rincome)). The model's explanatory power is substantial (R2 = 0.42, adj. R2
-      = 0.39). The model's intercept, corresponding to rincome = 0, is at 9.43 (95%
-      CI [6.69, 12.17], t(45) = 6.94, p < .001). Within this model:
-      
-        - The effect of rprice [log] is statistically significant and negative (beta =
-      -1.14, 95% CI [-1.87, -0.42], t(45) = -3.18, p = 0.003; Std. beta = -0.53, 95%
-      CI [-0.86, -0.20])
-        - The effect of rincome [log] is statistically non-significant and positive
-      (beta = 0.21, 95% CI [-0.33, 0.76], t(45) = 0.80, p = 0.429; Std. beta = 0.12,
-      95% CI [-0.14, 0.39])
-      
-      Standardized parameters were obtained by fitting the model on a standardized
-      version of the dataset. 95% Confidence Intervals (CIs) and p-values were
-      computed using a Wald t-distribution approximation. and We fitted a linear
-      model to predict packs with salestax (formula: log(packs) ~ log(rprice) +
-      log(rincome)). The model's explanatory power is substantial (R2 = 0.42, adj. R2
-      = 0.39). The model's intercept, corresponding to rprice = 0, is at 9.43 (95% CI
-      [6.69, 12.17], t(45) = 6.94, p < .001). Within this model:
+      We fitted a linear model to predict packs with rprice, rincome, salestax
+      (formula: log(packs) ~ log(rprice) + log(rincome)). The model's explanatory
+      power is substantial (R2 = 0.42, adj. R2 = 0.39). The model's intercept,
+      corresponding to rprice = 0, rincome = 0, is at 9.43 (95% CI [6.69, 12.17],
+      t(45) = 6.94, p < .001). Within this model:
       
         - The effect of rprice [log] is statistically significant and negative (beta =
       -1.14, 95% CI [-1.87, -0.42], t(45) = -3.18, p = 0.003; Std. beta = -0.53, 95%

--- a/tests/testthat/_snaps/windows/report.lm.md
+++ b/tests/testthat/_snaps/windows/report.lm.md
@@ -26,36 +26,12 @@
     Code
       report(lm(wt ~ as.factor(am) * as.factor(cyl), data = mtcars))
     Output
-      We fitted a linear model (estimated using OLS) to predict wt with am (formula:
-      wt ~ as.factor(am) * as.factor(cyl)). The model explains a statistically
-      significant and substantial proportion of variance (R2 = 0.73, F(5, 26) =
-      13.73, p < .001, adj. R2 = 0.67). The model's intercept, corresponding to am =
-      0, is at 2.94 (95% CI [2.27, 3.60], t(26) = 9.08, p < .001). Within this model:
-      
-        - The effect of am [1] is statistically significant and negative (beta = -0.89,
-      95% CI [-1.67, -0.11], t(26) = -2.36, p = 0.026; Std. beta = -0.91, 95% CI
-      [-1.71, -0.12])
-        - The effect of cyl [6] is statistically non-significant and positive (beta =
-      0.45, 95% CI [-0.43, 1.33], t(26) = 1.06, p = 0.298; Std. beta = 0.46, 95% CI
-      [-0.43, 1.36])
-        - The effect of cyl [8] is statistically significant and positive (beta = 1.17,
-      95% CI [0.43, 1.91], t(26) = 3.23, p = 0.003; Std. beta = 1.19, 95% CI [0.44,
-      1.95])
-        - The interaction effect of as cyl6 on am [1] is statistically non-significant
-      and positive (beta = 0.26, 95% CI [-0.92, 1.43], t(26) = 0.45, p = 0.654; Std.
-      beta = 0.26, 95% CI [-0.94, 1.47])
-        - The interaction effect of as cyl8 on am [1] is statistically non-significant
-      and positive (beta = 0.16, 95% CI [-1.02, 1.33], t(26) = 0.28, p = 0.783; Std.
-      beta = 0.16, 95% CI [-1.04, 1.36])
-      
-      Standardized parameters were obtained by fitting the model on a standardized
-      version of the dataset. 95% Confidence Intervals (CIs) and p-values were
-      computed using a Wald t-distribution approximation. and We fitted a linear
-      model (estimated using OLS) to predict wt with cyl (formula: wt ~ as.factor(am)
-      * as.factor(cyl)). The model explains a statistically significant and
-      substantial proportion of variance (R2 = 0.73, F(5, 26) = 13.73, p < .001, adj.
-      R2 = 0.67). The model's intercept, corresponding to cyl = 0, is at 2.94 (95% CI
-      [2.27, 3.60], t(26) = 9.08, p < .001). Within this model:
+      We fitted a linear model (estimated using OLS) to predict wt with am, cyl
+      (formula: wt ~ as.factor(am) * as.factor(cyl)). The model explains a
+      statistically significant and substantial proportion of variance (R2 = 0.73,
+      F(5, 26) = 13.73, p < .001, adj. R2 = 0.67). The model's intercept,
+      corresponding to am = 0, cyl = 0, is at 2.94 (95% CI [2.27, 3.60], t(26) =
+      9.08, p < .001). Within this model:
       
         - The effect of am [1] is statistically significant and negative (beta = -0.89,
       95% CI [-1.67, -0.11], t(26) = -2.36, p = 0.026; Std. beta = -0.91, 95% CI

--- a/tests/testthat/_snaps/windows/report.stanreg.md
+++ b/tests/testthat/_snaps/windows/report.stanreg.md
@@ -4,11 +4,11 @@
       report(model)
     Output
       We fitted a Bayesian linear model (estimated using MCMC sampling with 4 chains
-      of 300 iterations and a warmup of 150) to predict mpg with qsec (formula: mpg ~
-      qsec + wt). Priors over parameters were set as normal (mean = 0.00, SD = 8.43)
-      distributions. The model's explanatory power is substantial (R2 = 0.81, 95% CI
-      [0.70, 0.90], adj. R2 = 0.80). The model's intercept, corresponding to qsec =
-      0, is at 19.71 (95% CI [9.04, 30.18]). Within this model:
+      of 300 iterations and a warmup of 150) to predict mpg with qsec, wt (formula:
+      mpg ~ qsec + wt). Priors over parameters were set as normal (mean = 0.00, SD =
+      8.43) distributions. The model's explanatory power is substantial (R2 = 0.81,
+      95% CI [0.70, 0.90], adj. R2 = 0.80). The model's intercept, corresponding to
+      qsec = 0, wt = 0, is at 19.71 (95% CI [9.04, 30.18]). Within this model:
       
         - The effect of qsec (Median = 0.92, 95% CI [0.40, 1.47]) has a 99.83%
       probability of being positive (> 0), 99.00% of being significant (> 0.30), and
@@ -29,11 +29,12 @@
       assessed using R-hat, which should be below 1.01 (Vehtari et al., 2019), and
       Effective Sample Size (ESS), which should be greater than 1000 (Burkner, 2017).
       and We fitted a Bayesian linear model (estimated using MCMC sampling with 4
-      chains of 300 iterations and a warmup of 150) to predict mpg with wt (formula:
-      mpg ~ qsec + wt). Priors over parameters were set as normal (mean = 0.00, SD =
-      15.40) distributions. The model's explanatory power is substantial (R2 = 0.81,
-      95% CI [0.70, 0.90], adj. R2 = 0.80). The model's intercept, corresponding to
-      wt = 0, is at 19.71 (95% CI [9.04, 30.18]). Within this model:
+      chains of 300 iterations and a warmup of 150) to predict mpg with qsec, wt
+      (formula: mpg ~ qsec + wt). Priors over parameters were set as normal (mean =
+      0.00, SD = 15.40) distributions. The model's explanatory power is substantial
+      (R2 = 0.81, 95% CI [0.70, 0.90], adj. R2 = 0.80). The model's intercept,
+      corresponding to qsec = 0, wt = 0, is at 19.71 (95% CI [9.04, 30.18]). Within
+      this model:
       
         - The effect of qsec (Median = 0.92, 95% CI [0.40, 1.47]) has a 99.83%
       probability of being positive (> 0), 99.00% of being significant (> 0.30), and

--- a/tests/testthat/_snaps/windows/report.survreg.md
+++ b/tests/testthat/_snaps/windows/report.survreg.md
@@ -9,28 +9,11 @@
       Can't calculate log-loss.
       Can't calculate proper scoring rules for models without integer response values.
       `performance_pcp()` only works for models with binary response values.
-      We fitted a logistic model to predict Surv(futime, fustat) with ecog.ps
+      We fitted a logistic model to predict Surv(futime, fustat) with ecog.ps, rx
       (formula: Surv(futime, fustat) ~ ecog.ps + rx). The model's explanatory power
       is weak (Nagelkerke's R2 = 0.07). The model's intercept, corresponding to
-      ecog.ps = 0, is at 667.43 (95% CI [-415.59, 1750.45], p = 0.227). Within this
-      model:
-      
-        - The effect of ecog ps is statistically non-significant and negative (beta =
-      -210.59, 95% CI [-726.18, 305.01], p = 0.423; Std. beta = -107.06, 95% CI
-      [-369.19, 155.07])
-        - The effect of rx is statistically non-significant and positive (beta =
-      320.10, 95% CI [-194.11, 834.32], p = 0.222; Std. beta = 163.22, 95% CI
-      [-98.98, 425.42])
-        - The effect of Log(scale) is statistically significant and positive (beta =
-      5.82, 95% CI [5.35, 6.29], p < .001; Std. beta = 5.82, 95% CI [5.35, 6.29])
-      
-      Standardized parameters were obtained by fitting the model on a standardized
-      version of the dataset. 95% Confidence Intervals (CIs) and p-values were
-      computed using a Wald z-distribution approximation. and We fitted a logistic
-      model to predict Surv(futime, fustat) with rx (formula: Surv(futime, fustat) ~
-      ecog.ps + rx). The model's explanatory power is weak (Nagelkerke's R2 = 0.07).
-      The model's intercept, corresponding to rx = 0, is at 667.43 (95% CI [-415.59,
-      1750.45], p = 0.227). Within this model:
+      ecog.ps = 0, rx = 0, is at 667.43 (95% CI [-415.59, 1750.45], p = 0.227).
+      Within this model:
       
         - The effect of ecog ps is statistically non-significant and negative (beta =
       -210.59, 95% CI [-726.18, 305.01], p = 0.423; Std. beta = -107.06, 95% CI


### PR DESCRIPTION
Close #279. If ok, we need to update the snapshots in the tests. 

Changes: collapse predictors names and the intercept values in the first paragraph. 

New output:
``` r
library(report)
df <- carData::Mroz
x <- glm(lfp ~ k618 + wc + hc + inc, df, family=binomial(link="logit"))
report(x)
#> We fitted a logistic model (estimated using ML) to predict lfp with k618, wc,
#> hc, inc (formula: lfp ~ k618 + wc + hc + inc). The model's explanatory power is
#> weak (Tjur's R2 = 0.05). The model's intercept, corresponding to k618 = 0, wc =
#> no, hc = no, inc = 0, is at 0.64 (95% CI [0.31, 0.99], p < .001). Within this
#> model:
#> 
#>   - The effect of k618 is statistically non-significant and positive (beta =
#> 0.02, 95% CI [-0.10, 0.13], p = 0.790; Std. beta = 0.02, 95% CI [-0.13, 0.17])
#>   - The effect of wc [yes] is statistically significant and positive (beta =
#> 0.86, 95% CI [0.46, 1.27], p < .001; Std. beta = 0.86, 95% CI [0.46, 1.27])
#>   - The effect of hc [yes] is statistically non-significant and positive (beta =
#> 0.08, 95% CI [-0.29, 0.46], p = 0.658; Std. beta = 0.08, 95% CI [-0.29, 0.46])
#>   - The effect of inc is statistically significant and negative (beta = -0.03,
#> 95% CI [-0.05, -0.02], p < .001; Std. beta = -0.38, 95% CI [-0.55, -0.21])
#> 
#> Standardized parameters were obtained by fitting the model on a standardized
#> version of the dataset. 95% Confidence Intervals (CIs) and p-values were
#> computed using a Wald z-distribution approximation.
```

<sup>Created on 2022-09-01 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

