### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ aov(Sepal.Length ~ Species, data = iris) %>%
     # 
     # Effect sizes were labelled following Field's (2013) recommendations.
 
-### General Linear Models (GLMs)
+### Generalized Linear Models (GLMs)
 
 Reports are also compatible with GLMs, such as this **logistic
 regression**:


### PR DESCRIPTION
Change ### General Linear Models (GLMs)
to ### Generalized Linear Models (GLMs)

you are referring to a generalized linear model rather than a general linear model when using a logistic regression example. General linear models only use the Normal/ gaussian family.

# Description

This PR aims at being more precise in section heading

# Proposed Changes

I changed the heading  ### General Linear Models (GLMs) to  ### Generalized Linear Models (GLMs)
