### PR TITLE
no warn on get_data refactor

### DIFF
--- a/tests/testthat/test-report_intercept.R
+++ b/tests/testthat/test-report_intercept.R
@@ -23,6 +23,11 @@ data3 <- data.frame(
 contrasts(data1$f) <- cbind(c(1, 0, 0), c(0, 1, 0))
 data2$f <- relevel(data2$f, 3)
 
+# insight::get_data needs access to data in global environment
+data1 <<- data1
+data2 <<- data2
+data3 <<- data3
+
 # contrasts, ref. level = category 3
 m1 <- lm(y ~ f, data = data1)
 


### PR DESCRIPTION
Very minor change to avoid warnings with the upcoming `insight::get_data` refactor.

https://github.com/easystats/insight/pull/691