### PR TITLE
Use super-assignment to fix snapshot errors

### DIFF
--- a/tests/testthat/_snaps/windows/report.htest-t-test.md
+++ b/tests/testthat/_snaps/windows/report.htest-t-test.md
@@ -73,36 +73,36 @@
 ---
 
     Code
-      report(t.test(df$x, df$y, paired = TRUE))
+      report(t.test(x, y, paired = TRUE))
     Output
       Effect sizes were labelled following Cohen's (1988) recommendations.
       
-      The Paired t-test testing the difference between df$x and df$y (mean difference
-      = 0.43) suggests that the effect is positive, statistically significant, and
+      The Paired t-test testing the difference between x and y (mean difference =
+      0.43) suggests that the effect is positive, statistically significant, and
       large (difference = 0.43, 95% CI [0.10, 0.76], t(8) = 3.04, p = 0.016; Cohen's
       d = 1.01, 95% CI [0.18, 1.81])
 
 ---
 
     Code
-      report(t.test(df$x, df$y, paired = TRUE, alternative = "l"))
+      report(t.test(x, y, paired = TRUE, alternative = "l"))
     Output
       Effect sizes were labelled following Cohen's (1988) recommendations.
       
-      The Paired t-test testing the difference between df$x and df$y (mean difference
-      = 0.43) suggests that the effect is positive, statistically not significant,
-      and large (difference = 0.43, 95% CI [-Inf, 0.70], t(8) = 3.04, p = 0.992;
-      Cohen's d = 1.01, 95% CI [-Inf, 1.67])
+      The Paired t-test testing the difference between x and y (mean difference =
+      0.43) suggests that the effect is positive, statistically not significant, and
+      large (difference = 0.43, 95% CI [-Inf, 0.70], t(8) = 3.04, p = 0.992; Cohen's
+      d = 1.01, 95% CI [-Inf, 1.67])
 
 ---
 
     Code
-      report(t.test(df$x, df$y, paired = TRUE, alternative = "g"))
+      report(t.test(x, y, paired = TRUE, alternative = "g"))
     Output
       Effect sizes were labelled following Cohen's (1988) recommendations.
       
-      The Paired t-test testing the difference between df$x and df$y (mean difference
-      = 0.43) suggests that the effect is positive, statistically significant, and
+      The Paired t-test testing the difference between x and y (mean difference =
+      0.43) suggests that the effect is positive, statistically significant, and
       large (difference = 0.43, 95% CI [0.17, Inf], t(8) = 3.04, p = 0.008; Cohen's d
       = 1.01, 95% CI [0.30, Inf])
 

--- a/tests/testthat/test-report.htest-t-test.R
+++ b/tests/testthat/test-report.htest-t-test.R
@@ -47,21 +47,20 @@ test_that("report.htest-t-test", {
 
   # two-sample paired t-test ---------------------
 
-  x <- c(1.83, 0.50, 1.62, 2.48, 1.68, 1.88, 1.55, 3.06, 1.30)
-  y <- c(0.878, 0.647, 0.598, 2.05, 1.06, 1.29, 1.06, 3.14, 1.29)
-  df <- data.frame(x, y)
+  x <<- c(1.83, 0.50, 1.62, 2.48, 1.68, 1.88, 1.55, 3.06, 1.30)
+  y <<- c(0.878, 0.647, 0.598, 2.05, 1.06, 1.29, 1.06, 3.14, 1.29)
 
   set.seed(123)
-  expect_snapshot(variant = "windows", report(t.test(df$x, df$y, paired = TRUE)))
+  expect_snapshot(variant = "windows", report(t.test(x, y, paired = TRUE)))
 
   set.seed(123)
-  expect_snapshot(variant = "windows", report(t.test(df$x, df$y, paired = TRUE, alternative = "l")))
+  expect_snapshot(variant = "windows", report(t.test(x, y, paired = TRUE, alternative = "l")))
 
   set.seed(123)
-  expect_snapshot(variant = "windows", report(t.test(df$x, df$y, paired = TRUE, alternative = "g")))
+  expect_snapshot(variant = "windows", report(t.test(x, y, paired = TRUE, alternative = "g")))
 
   if (getRversion() > "4.0") {
-    sleep2 <- reshape(sleep, direction = "wide", idvar = "ID", timevar = "group")
+    sleep2 <<- reshape(sleep, direction = "wide", idvar = "ID", timevar = "group")
     set.seed(123)
     expect_snapshot(
       variant = "windows",


### PR DESCRIPTION
Use super-assignment to fix snapshot errors, as discussed in #327