### PR TITLE
Suppress warnings in all stan functions

### DIFF
--- a/R/report_intercept.R
+++ b/R/report_intercept.R
@@ -26,7 +26,7 @@
 #'
 #' # Bayesian models
 #' if (require("rstanarm")) {
-#'   model <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600)
+#'   model <- suppressWarnings(stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600))
 #'   report_intercept(model)
 #' }
 #' }

--- a/R/report_model.R
+++ b/R/report_model.R
@@ -32,7 +32,7 @@
 #'
 #' # Bayesian models
 #' if (require("rstanarm")) {
-#'   model <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600)
+#'   model <- suppressWarnings(stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600))
 #'   report_model(model)
 #' }
 #' }

--- a/R/report_parameters.R
+++ b/R/report_parameters.R
@@ -44,7 +44,7 @@
 #'
 #' # Bayesian models
 #' if (require("rstanarm")) {
-#'   model <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600)
+#'   model <- suppressWarnings(stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600))
 #'   report_parameters(model)
 #' }
 #' }

--- a/R/report_performance.R
+++ b/R/report_performance.R
@@ -29,7 +29,7 @@
 #'
 #' # Bayesian models
 #' if (require("rstanarm")) {
-#'   model <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600)
+#'   model <- suppressWarnings(stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600))
 #'   report_performance(model)
 #' }
 #'

--- a/R/report_statistics.R
+++ b/R/report_statistics.R
@@ -39,7 +39,7 @@
 #'
 #' # Bayesian models
 #' if (require("rstanarm")) {
-#'   model <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600)
+#'   model <- suppressWarnings(stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600))
 #'   report_statistics(model)
 #' }
 #' }

--- a/R/report_table.R
+++ b/R/report_table.R
@@ -40,7 +40,7 @@
 #'
 #' # Bayesian models
 #' if (require("rstanarm")) {
-#'   model <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600)
+#'   model <- suppressWarnings(stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600))
 #'   report_table(model, effectsize_method = "basic")
 #' }
 #'

--- a/man/report_intercept.Rd
+++ b/man/report_intercept.Rd
@@ -35,7 +35,7 @@ if (require("lme4")) {
 
 # Bayesian models
 if (require("rstanarm")) {
-  model <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600)
+  model <- suppressWarnings(stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600))
   report_intercept(model)
 }
 }

--- a/man/report_model.Rd
+++ b/man/report_model.Rd
@@ -44,7 +44,7 @@ if (require("lme4")) {
 
 # Bayesian models
 if (require("rstanarm")) {
-  model <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600)
+  model <- suppressWarnings(stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600))
   report_model(model)
 }
 }

--- a/man/report_parameters.Rd
+++ b/man/report_parameters.Rd
@@ -53,7 +53,7 @@ if (require("lme4")) {
 
 # Bayesian models
 if (require("rstanarm")) {
-  model <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600)
+  model <- suppressWarnings(stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600))
   report_parameters(model)
 }
 }

--- a/man/report_performance.Rd
+++ b/man/report_performance.Rd
@@ -41,7 +41,7 @@ if (require("lme4")) {
 
 # Bayesian models
 if (require("rstanarm")) {
-  model <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600)
+  model <- suppressWarnings(stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600))
   report_performance(model)
 }
 

--- a/man/report_statistics.Rd
+++ b/man/report_statistics.Rd
@@ -51,7 +51,7 @@ if (require("lme4")) {
 
 # Bayesian models
 if (require("rstanarm")) {
-  model <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600)
+  model <- suppressWarnings(stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600))
   report_statistics(model)
 }
 }

--- a/man/report_table.Rd
+++ b/man/report_table.Rd
@@ -52,7 +52,7 @@ if (require("lme4")) {
 
 # Bayesian models
 if (require("rstanarm")) {
-  model <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600)
+  model <- suppressWarnings(stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 600))
   report_table(model, effectsize_method = "basic")
 }
 


### PR DESCRIPTION
It seems that stan very inconsistently generates warnings, so to fix the current failing examples workflow, I decided to suppress warnings in all such functions.