### PR TITLE
Simplify conditional expressions in tests: Part-2

### DIFF
--- a/R/report.brmsfit.R
+++ b/R/report.brmsfit.R
@@ -66,8 +66,8 @@ report_priors.brmsfit <- function(x, ...) {
 
   # Return empty if no priors info
   if (!"Prior_Distribution" %in% names(params) ||
-    nrow(params) == 0 ||
-    all(is.na(params$Prior_Scale))) {
+        nrow(params) == 0 ||
+        all(is.na(params$Prior_Scale))) {
     return("")
   }
 

--- a/R/report.numeric.R
+++ b/R/report.numeric.R
@@ -191,9 +191,9 @@ report_parameters.numeric <- function(x,
     if (isTRUE(missing_percentage)) {
       n_missing <- table$percentage_Missing[1]
       text_missing <- paste0(insight::format_value(table$percentage_Missing[1],
-        protect_integers = TRUE,
-        digits = digits
-      ), "% missing")
+                               protect_integers = TRUE,
+                               digits = digits
+                             ), "% missing")
     } else {
       n_missing <- table$n_Missing[1]
       text_missing <- paste0(table$n_Missing[1], " missing")

--- a/tests/testthat/_snaps/windows/report.htest-chi2.md
+++ b/tests/testthat/_snaps/windows/report.htest-chi2.md
@@ -82,6 +82,15 @@
 ---
 
     Code
+      report_effectsize(x, type = "cohens_w")
+    Output
+      Effect sizes were labelled following Funder's (2019) recommendations. 
+      
+      small (Cohens_w = 0.10, 95% CI [0.07, 1.00])
+
+---
+
+    Code
       report_effectsize(x, type = "phi")
     Output
       Effect sizes were labelled following Funder's (2019) recommendations. 

--- a/tests/testthat/_snaps/windows/report.htest-wilcox.md
+++ b/tests/testthat/_snaps/windows/report.htest-wilcox.md
@@ -1,0 +1,82 @@
+# report.htest-wilcox
+
+    Code
+      report(wilcox.test(x, y, paired = TRUE, data = mtcars))
+    Output
+      Effect sizes were labelled following Funder's (2019) recommendations.
+      
+      The Wilcoxon signed rank exact test testing the difference in ranks between x
+      and y suggests that the effect is positive, statistically significant, and very
+      large (W = 40.00, p = 0.039; r (rank biserial) = 0.78, 95% CI [0.30, 0.94])
+
+---
+
+    Code
+      report(wilcox.test(x, y, paired = TRUE, data = mtcars, alternative = "l"))
+    Output
+      Effect sizes were labelled following Funder's (2019) recommendations.
+      
+      The Wilcoxon signed rank exact test testing the difference in ranks between x
+      and y suggests that the effect is positive, statistically not significant, and
+      very large (W = 40.00, p = 0.986; r (rank biserial) = 0.78, 95% CI [-1.00,
+      0.93])
+
+---
+
+    Code
+      report(wilcox.test(x, y, paired = TRUE, data = mtcars, alternative = "g"))
+    Output
+      Effect sizes were labelled following Funder's (2019) recommendations.
+      
+      The Wilcoxon signed rank exact test testing the difference in ranks between x
+      and y suggests that the effect is positive, statistically significant, and very
+      large (W = 40.00, p = 0.020; r (rank biserial) = 0.78, 95% CI [0.40, 1.00])
+
+---
+
+    Code
+      report(wilcox.test(mtcars$am, mtcars$wt, exact = FALSE))
+    Output
+      Effect sizes were labelled following Funder's (2019) recommendations.
+      
+      The Wilcoxon rank sum test with continuity correction testing the difference in
+      ranks between mtcars$am and mtcars$wt suggests that the effect is negative,
+      statistically significant, and very large (W = 0.00, p < .001; r (rank
+      biserial) = -1.00, 95% CI [-1.00, -1.00])
+
+---
+
+    Code
+      report(wilcox.test(mtcars$am, mtcars$wt, alternative = "l", exact = FALSE))
+    Output
+      Effect sizes were labelled following Funder's (2019) recommendations.
+      
+      The Wilcoxon rank sum test with continuity correction testing the difference in
+      ranks between mtcars$am and mtcars$wt suggests that the effect is negative,
+      statistically significant, and very large (W = 0.00, p < .001; r (rank
+      biserial) = -1.00, 95% CI [-1.00, -1.00])
+
+---
+
+    Code
+      report(wilcox.test(mtcars$am, mtcars$mpg, exact = FALSE, correct = FALSE))
+    Output
+      Effect sizes were labelled following Funder's (2019) recommendations.
+      
+      The Wilcoxon rank sum test testing the difference in ranks between mtcars$am
+      and mtcars$mpg suggests that the effect is negative, statistically significant,
+      and very large (W = 0.00, p < .001; r (rank biserial) = -1.00, 95% CI [-1.00,
+      -1.00])
+
+---
+
+    Code
+      report(wilcox.test(depression$change, mu = 1))
+    Output
+      Effect sizes were labelled following Funder's (2019) recommendations.
+      
+      The Wilcoxon signed rank exact test testing the difference in rank for
+      depression$change and true location of 0 suggests that the effect is negative,
+      statistically significant, and very large (W = 0.00, p = 0.004; r (rank
+      biserial) = -1.00, 95% CI [-1.00, -1.00])
+

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,14 +1,14 @@
-requiet <- function(package) {
+skip_if_not_or_load_if_installed <- function(package) {
   testthat::skip_if_not_installed(package)
   suppressPackageStartupMessages(
     require(package, warn.conflicts = FALSE, character.only = TRUE)
   )
 }
 
-# requiet all hard dependencies
-requiet("bayestestR")
-requiet("insight")
-requiet("datawizard")
-requiet("effectsize")
-requiet("parameters")
-requiet("performance")
+# skip_if_not_or_load_if_installed all hard dependencies
+skip_if_not_or_load_if_installed("bayestestR")
+skip_if_not_or_load_if_installed("insight")
+skip_if_not_or_load_if_installed("datawizard")
+skip_if_not_or_load_if_installed("effectsize")
+skip_if_not_or_load_if_installed("parameters")
+skip_if_not_or_load_if_installed("performance")

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -5,7 +5,7 @@ skip_if_not_or_load_if_installed <- function(package) {
   )
 }
 
-# skip_if_not_or_load_if_installed all hard dependencies
+# load all hard dependencies to use them without namespacing
 skip_if_not_or_load_if_installed("bayestestR")
 skip_if_not_or_load_if_installed("insight")
 skip_if_not_or_load_if_installed("datawizard")

--- a/tests/testthat/test-format_model.R
+++ b/tests/testthat/test-format_model.R
@@ -7,7 +7,7 @@ test_that("format_model", {
 
 
 test_that("format_model", {
-  requiet("lme4")
+  skip_if_not_or_load_if_installed("lme4")
   expect_identical(format_model(lme4::lmer(wt ~ cyl + (1 | gear), data = mtcars)), "linear mixed model")
   expect_identical(
     format_model(lme4::glmer(vs ~ cyl + (1 | gear), data = mtcars, family = "binomial")),
@@ -23,18 +23,18 @@ test_that("format_model", {
 
 
 test_that("format_model", {
-  requiet("rstanarm")
+  skip_if_not_or_load_if_installed("rstanarm")
   expect_identical(
     format_model(suppressWarnings(rstanarm::stan_glm(mpg ~ wt, data = mtcars, refresh = 0, iter = 50))),
     "Bayesian linear model"
   )
   expect_identical(
     format_model(suppressWarnings(rstanarm::stan_glm(vs ~ wt,
-      data = mtcars,
-      family = "binomial",
-      refresh = 0,
-      iter = 50
-    ))),
+                                    data = mtcars,
+                                    family = "binomial",
+                                    refresh = 0,
+                                    iter = 50
+                                  ))),
     "Bayesian logistic model"
   )
 })

--- a/tests/testthat/test-report.brmsfit.R
+++ b/tests/testthat/test-report.brmsfit.R
@@ -1,34 +1,34 @@
-if (requiet("brms")) {
-  test_that("report.brms", {
-    # too strict; exact values will change depending on the platform
-    # so worth checking only locally
-    skip_on_ci()
+skip_if_not_or_load_if_installed("brms")
 
-    set.seed(333)
-    model <- suppressWarnings(brm(mpg ~ qsec + wt, data = mtcars, refresh = 0, iter = 300, seed = 333))
-    r <- report(model, verbose = FALSE)
+test_that("report.brms", {
+  # too strict; exact values will change depending on the platform
+  # so worth checking only locally
+  skip_on_ci()
 
-    expect_s3_class(summary(r), "character")
-    expect_s3_class(as.data.frame(r), "data.frame")
+  set.seed(333)
+  model <- suppressWarnings(brm(mpg ~ qsec + wt, data = mtcars, refresh = 0, iter = 300, seed = 333))
+  r <- report(model, verbose = FALSE)
 
-    expect_snapshot(variant = "windows", report(model, verbose = FALSE))
+  expect_s3_class(summary(r), "character")
+  expect_s3_class(as.data.frame(r), "data.frame")
 
-    expect_identical(
-      as.data.frame(r)$Parameter,
-      c(
-        "(Intercept)", "qsec", "wt", "sigma", NA, "ELPD", "LOOIC", "WAIC", "R2",
-        "R2 (adj.)", "Sigma"
-      )
+  expect_snapshot(variant = "windows", report(model, verbose = FALSE))
+
+  expect_identical(
+    as.data.frame(r)$Parameter,
+    c(
+      "(Intercept)", "qsec", "wt", "sigma", NA, "ELPD", "LOOIC", "WAIC", "R2",
+      "R2 (adj.)", "Sigma"
     )
-    expect_equal(
-      as.data.frame(r)$Median,
-      c(19.906865, 0.930295, -5.119548, 2.6611623, rep(NA, 7)),
-      tolerance = 1e-1
-    )
-    expect_equal(
-      as.data.frame(r)$pd,
-      c(rep(1, 4), rep(NA, 7)),
-      tolerance = 1e-1
-    )
-  })
-}
+  )
+  expect_equal(
+    as.data.frame(r)$Median,
+    c(19.906865, 0.930295, -5.119548, 2.6611623, rep(NA, 7)),
+    tolerance = 1e-1
+  )
+  expect_equal(
+    as.data.frame(r)$pd,
+    c(rep(1, 4), rep(NA, 7)),
+    tolerance = 1e-1
+  )
+})

--- a/tests/testthat/test-report.brmsfit.R
+++ b/tests/testthat/test-report.brmsfit.R
@@ -1,6 +1,8 @@
 skip_if_not_or_load_if_installed("brms")
 
 test_that("report.brms", {
+  testthat::skip_if_not(packageVersion("rstan") >= "2.26.0")
+
   set.seed(333)
   model <- suppressWarnings(brm(mpg ~ qsec + wt, data = mtcars, refresh = 0, iter = 300, seed = 333))
   r <- report(model, verbose = FALSE)

--- a/tests/testthat/test-report.brmsfit.R
+++ b/tests/testthat/test-report.brmsfit.R
@@ -1,10 +1,6 @@
 skip_if_not_or_load_if_installed("brms")
 
 test_that("report.brms", {
-  # too strict; exact values will change depending on the platform
-  # so worth checking only locally
-  skip_on_ci()
-
   set.seed(333)
   model <- suppressWarnings(brm(mpg ~ qsec + wt, data = mtcars, refresh = 0, iter = 300, seed = 333))
   r <- report(model, verbose = FALSE)

--- a/tests/testthat/test-report.data.frame.R
+++ b/tests/testthat/test-report.data.frame.R
@@ -43,8 +43,7 @@ test_that("report.factor", {
 })
 
 test_that("report.data.frame", {
-  skip_if_not_installed("dplyr")
-  library(dplyr)
+  skip_if_not_or_load_if_installed("dplyr")
 
   r <- report(iris)
   expect_equal(nrow(as.data.frame(r)), 7, tolerance = 0)
@@ -69,19 +68,18 @@ test_that("report.data.frame", {
 })
 
 test_that("report.data.frame - with NAs", {
-  skip_if_not_installed("dplyr")
-  library(dplyr)
+  skip_if_not_or_load_if_installed("dplyr")
 
   df <- mtcars
   df[1, 2] <- NA
   df[1, 6] <- NA
 
-  report_grouped_df <- suppressWarnings(report(group_by(df, cyl)))
+  report_grouped_df <- report(group_by(df, cyl))
   expect_snapshot(variant = "windows", report_grouped_df)
 })
 
 test_that("report.data.frame - with list columns", {
-  skip_if_not_installed("dplyr")
+  skip_if_not_or_load_if_installed("dplyr")
 
   set.seed(123)
   expect_snapshot(variant = "windows", report(dplyr::starwars))

--- a/tests/testthat/test-report.htest-chi2.R
+++ b/tests/testthat/test-report.htest-chi2.R
@@ -48,12 +48,12 @@ test_that("report.htest-chi2", {
   expect_snapshot(
     variant = "windows",
     report_effectsize(x, type = "tschuprows_t")
-  ) # tschuprows_t has no interpretation in effectsize!!!
-  # Watch carefully in case effectsize adds support
+  )
 
-  # max_possible not found for cohens_w
-  # report_effectsize(x, type = "cohens_w")
-  # Watch carefully in case effectsize adds support
+  expect_snapshot(
+    variant = "windows",
+    report_effectsize(x, type = "cohens_w")
+  )
 
   # Change dataset for "Error: Phi is not appropriate for non-2x2 tables."
   dat <- structure(

--- a/tests/testthat/test-report.htest-correlation.R
+++ b/tests/testthat/test-report.htest-correlation.R
@@ -4,7 +4,7 @@ test_that("report.htest-correlation", {
   expect_equal(as.report_table(r)$r, -0.117, tolerance = 0.01)
 
   set.seed(123)
-  r <- suppressWarnings(cor.test(iris$Sepal.Width, iris$Sepal.Length, method = "spearman"))
+  r <- cor.test(iris$Sepal.Width, iris$Sepal.Length, method = "spearman", exact = FALSE)
   r <- report(r)
   expect_equal(as.report_table(r)$rho, -0.166, tolerance = 0.01)
 

--- a/tests/testthat/test-report.htest-wilcox.R
+++ b/tests/testthat/test-report.htest-wilcox.R
@@ -1,33 +1,25 @@
 # skip for now
-if (FALSE) {
-  test_that("report.htest-wilcox", {
-    # paired wilcox test ---------------------
+test_that("report.htest-wilcox", {
+  # paired wilcox test ---------------------
 
-    x <- c(1.83, 0.50, 1.62, 2.48, 1.68, 1.88, 1.55, 3.06, 1.30)
-    y <- c(0.878, 0.647, 0.598, 2.05, 1.06, 1.29, 1.06, 3.14, 1.29)
-    set.seed(123)
-    expect_snapshot(variant = "windows", report(wilcox.test(x, y, paired = TRUE, data = mtcars)))
+  x <<- c(1.83, 0.50, 1.62, 2.48, 1.68, 1.88, 1.55, 3.06, 1.30)
+  y <<- c(0.878, 0.647, 0.598, 2.05, 1.06, 1.29, 1.06, 3.14, 1.29)
+  expect_snapshot(variant = "windows", report(wilcox.test(x, y, paired = TRUE, data = mtcars)))
 
-    set.seed(123)
-    expect_snapshot(variant = "windows", report(wilcox.test(x, y, paired = TRUE, data = mtcars, alternative = "l")))
+  expect_snapshot(variant = "windows", report(wilcox.test(x, y, paired = TRUE, data = mtcars, alternative = "l")))
 
-    set.seed(123)
-    expect_snapshot(variant = "windows", report(wilcox.test(x, y, paired = TRUE, data = mtcars, alternative = "g")))
+  expect_snapshot(variant = "windows", report(wilcox.test(x, y, paired = TRUE, data = mtcars, alternative = "g")))
 
-    # unpaired wilcox test ---------------------
+  # unpaired wilcox test ---------------------
 
-    set.seed(123)
-    expect_snapshot(variant = "windows", report(wilcox.test(mtcars$am, mtcars$wt)))
+  expect_snapshot(variant = "windows", report(wilcox.test(mtcars$am, mtcars$wt, exact = FALSE)))
 
-    set.seed(123)
-    expect_snapshot(variant = "windows", report(wilcox.test(mtcars$am, mtcars$wt, alternative = "l")))
+  expect_snapshot(variant = "windows", report(wilcox.test(mtcars$am, mtcars$wt, alternative = "l", exact = FALSE)))
 
-    set.seed(123)
-    expect_snapshot(variant = "windows", report(wilcox.test(mtcars$am, mtcars$mpg, exact = FALSE, correct = FALSE)))
+  expect_snapshot(variant = "windows", report(wilcox.test(mtcars$am, mtcars$mpg, exact = FALSE, correct = FALSE)))
 
-    # one-sample wilcox test ---------------------
+  # one-sample wilcox test ---------------------
 
-    depression <- data.frame(first = x, second = y, change = y - x)
-    expect_snapshot(variant = "windows", report(wilcox.test(depression$change, mu = 1)))
-  })
-}
+  depression <<- data.frame(first = x, second = y, change = y - x)
+  expect_snapshot(variant = "windows", report(wilcox.test(depression$change, mu = 1)))
+})

--- a/tests/testthat/test-report.ivreg.R
+++ b/tests/testthat/test-report.ivreg.R
@@ -1,15 +1,13 @@
-if (requiet("ivreg")) {
-  test_that("report-survreg", {
-    data("CigaretteDemand", package = "ivreg")
+skip_if_not_or_load_if_installed("ivreg")
+test_that("report-survreg", {
+  data("CigaretteDemand", package = "ivreg")
 
+  # model
+  set.seed(123)
+  ivr <-
+    ivreg(log(packs) ~ log(rprice) + log(rincome) | salestax + log(rincome),
+      data = CigaretteDemand
+    )
 
-    # model
-    set.seed(123)
-    ivr <-
-      ivreg(log(packs) ~ log(rprice) + log(rincome) | salestax + log(rincome),
-        data = CigaretteDemand
-      )
-
-    expect_snapshot(variant = "windows", report(ivr))
-  })
-}
+  expect_snapshot(variant = "windows", report(ivr))
+})

--- a/tests/testthat/test-report.lavaan.R
+++ b/tests/testthat/test-report.lavaan.R
@@ -1,21 +1,20 @@
-if (requiet("lavaan")) {
-  structure <- " ind60 =~ x1 + x2 + x3
+skip_if_not_or_load_if_installed("lavaan")
+structure <- " ind60 =~ x1 + x2 + x3
   dem60 =~ y1 + y2 + y3
   dem60 ~ ind60 "
 
-  set.seed(123)
-  model <- lavaan::sem(structure, data = PoliticalDemocracy)
+set.seed(123)
+model <- lavaan::sem(structure, data = PoliticalDemocracy)
 
-  # Specific reports
-  test_that("model-lavaan detailed report", {
-    expect_snapshot(variant = "windows", report(model))
-  })
+# Specific reports
+test_that("model-lavaan detailed report", {
+  expect_snapshot(variant = "windows", report(model))
+})
 
-  test_that("model-lavaan detailed table", {
-    expect_snapshot(variant = "windows", report_table(model))
-  })
+test_that("model-lavaan detailed table", {
+  expect_snapshot(variant = "windows", report_table(model))
+})
 
-  test_that("model-lavaan detailed performance", {
-    expect_snapshot(variant = "windows", report_performance(model))
-  })
-}
+test_that("model-lavaan detailed performance", {
+  expect_snapshot(variant = "windows", report_performance(model))
+})

--- a/tests/testthat/test-report.lmer.R
+++ b/tests/testthat/test-report.lmer.R
@@ -1,23 +1,23 @@
-if (requiet("lme4")) {
-  test_that("report-lmer", {
-    df <- lme4::sleepstudy
-    set.seed(123)
-    df$mygrp <- sample(1:5, size = 180, replace = TRUE)
-    df$mysubgrp <- NA
-    for (i in 1:5) {
-      filter_group <- df$mygrp == i
-      df$mysubgrp[filter_group] <-
-        sample(1:30, size = sum(filter_group), replace = TRUE)
-    }
+skip_if_not_or_load_if_installed("lme4")
 
-    set.seed(123)
-    m1 <- lme4::lmer(Reaction ~ Days + (1 + Days | Subject), data = df)
+test_that("report-lmer", {
+  df <- lme4::sleepstudy
+  set.seed(123)
+  df$mygrp <- sample(1:5, size = 180, replace = TRUE)
+  df$mysubgrp <- NA
+  for (i in 1:5) {
+    filter_group <- df$mygrp == i
+    df$mysubgrp[filter_group] <-
+      sample(1:30, size = sum(filter_group), replace = TRUE)
+  }
 
-    set.seed(123)
-    m2 <- lme4::lmer(Reaction ~ Days + (1 | mygrp / mysubgrp) + (1 | Subject), data = df)
+  set.seed(123)
+  m1 <- lme4::lmer(Reaction ~ Days + (1 + Days | Subject), data = df)
 
-    expect_snapshot(variant = "windows", report(m1))
+  set.seed(123)
+  m2 <- lme4::lmer(Reaction ~ Days + (1 | mygrp / mysubgrp) + (1 | Subject), data = df)
 
-    expect_snapshot(variant = "windows", report(m2))
-  })
-}
+  expect_snapshot(variant = "windows", report(m1))
+
+  expect_snapshot(variant = "windows", report(m2))
+})

--- a/tests/testthat/test-report.stanreg.R
+++ b/tests/testthat/test-report.stanreg.R
@@ -1,36 +1,35 @@
-if (requiet("rstanarm")) {
-  set.seed(123)
-  model <- suppressWarnings(stan_glm(mpg ~ qsec + wt, data = mtcars, refresh = 0, iter = 300))
+skip_if_not_or_load_if_installed("rstanarm")
+set.seed(123)
+model <- suppressWarnings(stan_glm(mpg ~ qsec + wt, data = mtcars, refresh = 0, iter = 300))
 
-  test_that("model-stanreg", {
-    r <- report(model, centrality = "mean")
-    expect_s3_class(summary(r), "character")
-    expect_s3_class(as.data.frame(r), "data.frame")
+test_that("model-stanreg", {
+  r <- report(model, centrality = "mean")
+  expect_s3_class(summary(r), "character")
+  expect_s3_class(as.data.frame(r), "data.frame")
 
-    expect_identical(
-      as.data.frame(r)$Parameter,
-      c(
-        "(Intercept)", "qsec", "wt", NA, "ELPD", "LOOIC", "WAIC", "R2",
-        "R2 (adj.)", "Sigma"
-      )
+  expect_identical(
+    as.data.frame(r)$Parameter,
+    c(
+      "(Intercept)", "qsec", "wt", NA, "ELPD", "LOOIC", "WAIC", "R2",
+      "R2 (adj.)", "Sigma"
     )
-    expect_equal(
-      as.data.frame(r)$Mean,
-      c(
-        19.6150397292409, 0.937896549338215, -5.04660975597389, NA,
-        NA, NA, NA, NA, NA, NA
-      ),
-      tolerance = 1e-1
-    )
-    expect_equal(
-      as.data.frame(r)$pd,
-      c(0.998333333333333, 0.998333333333333, 1, NA, NA, NA, NA, NA, NA, NA),
-      tolerance = 1e-1
-    )
-  })
+  )
+  expect_equal(
+    as.data.frame(r)$Mean,
+    c(
+      19.6150397292409, 0.937896549338215, -5.04660975597389, NA,
+      NA, NA, NA, NA, NA, NA
+    ),
+    tolerance = 1e-1
+  )
+  expect_equal(
+    as.data.frame(r)$pd,
+    c(0.998333333333333, 0.998333333333333, 1, NA, NA, NA, NA, NA, NA, NA),
+    tolerance = 1e-1
+  )
+})
 
-  test_that("model-stanreg detailed", {
-    skip_on_ci()
-    expect_snapshot(variant = "windows", report(model))
-  })
-}
+test_that("model-stanreg detailed", {
+  skip_on_ci()
+  expect_snapshot(variant = "windows", report(model))
+})

--- a/tests/testthat/test-report.stanreg.R
+++ b/tests/testthat/test-report.stanreg.R
@@ -30,6 +30,5 @@ test_that("model-stanreg", {
 })
 
 test_that("model-stanreg detailed", {
-  skip_on_ci()
   expect_snapshot(variant = "windows", report(model))
 })

--- a/tests/testthat/test-report.survreg.R
+++ b/tests/testthat/test-report.survreg.R
@@ -1,5 +1,5 @@
 test_that("report-survreg", {
-  requiet("survival")
+  skip_if_not_or_load_if_installed("survival")
 
   set.seed(123)
   mod_survreg <- survival::survreg(

--- a/tests/testthat/test-report_performance.R
+++ b/tests/testthat/test-report_performance.R
@@ -27,105 +27,106 @@ test_that("report_performance", {
   )
 
   # Mixed models
-  if (requiet("lme4")) {
-    x <- lme4::lmer(Sepal.Length ~ Petal.Length + (1 | Species), data = iris)
-    expect_identical(
-      as.character(report_performance(x)),
-      paste(
-        "The model's total explanatory power is substantial (conditional R2 = 0.97) and the",
-        "part related to the fixed effects alone (marginal R2) is of 0.66"
-      )
-    )
-    expect_identical(
-      as.character(summary(report_performance(x))),
-      paste(
-        "The model's total explanatory power is substantial (conditional R2 = 0.97) and the",
-        "part related to the fixed effects alone (marginal R2) is of 0.66"
-      )
-    )
+  skip_if_not_or_load_if_installed("lme4")
 
-    x <- lme4::glmer(vs ~ mpg + (1 | cyl), data = mtcars, family = "binomial")
-    expect_identical(
-      as.character(report_performance(x)),
-      paste(
-        "The model's total explanatory power is substantial (conditional R2 = 0.59) and the",
-        "part related to the fixed effects alone (marginal R2) is of 0.13"
-      )
+  x <- lme4::lmer(Sepal.Length ~ Petal.Length + (1 | Species), data = iris)
+  expect_identical(
+    as.character(report_performance(x)),
+    paste(
+      "The model's total explanatory power is substantial (conditional R2 = 0.97) and the",
+      "part related to the fixed effects alone (marginal R2) is of 0.66"
     )
-    expect_identical(
-      as.character(summary(report_performance(x))),
-      paste(
-        "The model's total explanatory power is substantial (conditional R2 = 0.59) and the",
-        "part related to the fixed effects alone (marginal R2) is of 0.13"
-      )
+  )
+  expect_identical(
+    as.character(summary(report_performance(x))),
+    paste(
+      "The model's total explanatory power is substantial (conditional R2 = 0.97) and the",
+      "part related to the fixed effects alone (marginal R2) is of 0.66"
     )
-  }
+  )
+
+  x <- lme4::glmer(vs ~ mpg + (1 | cyl), data = mtcars, family = "binomial")
+  expect_identical(
+    as.character(report_performance(x)),
+    paste(
+      "The model's total explanatory power is substantial (conditional R2 = 0.59) and the",
+      "part related to the fixed effects alone (marginal R2) is of 0.13"
+    )
+  )
+  expect_identical(
+    as.character(summary(report_performance(x))),
+    paste(
+      "The model's total explanatory power is substantial (conditional R2 = 0.59) and the",
+      "part related to the fixed effects alone (marginal R2) is of 0.13"
+    )
+  )
+
 
   # Mixed models
-  if (requiet("lme4")) {
-    x <- lmer(Sepal.Length ~ Petal.Length + (1 | Species), data = iris)
-    expect_identical(
-      as.character(report_performance(x)),
-      paste(
-        "The model's total explanatory power is substantial (conditional R2 = 0.97) and the",
-        "part related to the fixed effects alone (marginal R2) is of 0.66"
-      )
-    )
-    expect_identical(
-      as.character(summary(report_performance(x))),
-      paste(
-        "The model's total explanatory power is substantial (conditional R2 = 0.97) and the",
-        "part related to the fixed effects alone (marginal R2) is of 0.66"
-      )
-    )
+  skip_if_not_or_load_if_installed("lme4")
 
-    x <- lme4::glmer(vs ~ mpg + (1 | cyl), data = mtcars, family = "binomial")
-    expect_identical(
-      as.character(report_performance(x)),
-      paste(
-        "The model's total explanatory power is substantial (conditional R2 = 0.59) and the",
-        "part related to the fixed effects alone (marginal R2) is of 0.13"
-      )
+  x <- lmer(Sepal.Length ~ Petal.Length + (1 | Species), data = iris)
+  expect_identical(
+    as.character(report_performance(x)),
+    paste(
+      "The model's total explanatory power is substantial (conditional R2 = 0.97) and the",
+      "part related to the fixed effects alone (marginal R2) is of 0.66"
     )
-    expect_identical(
-      as.character(summary(report_performance(x))),
-      paste(
-        "The model's total explanatory power is substantial (conditional R2 = 0.59) and the",
-        "part related to the fixed effects alone (marginal R2) is of 0.13"
-      )
+  )
+  expect_identical(
+    as.character(summary(report_performance(x))),
+    paste(
+      "The model's total explanatory power is substantial (conditional R2 = 0.97) and the",
+      "part related to the fixed effects alone (marginal R2) is of 0.66"
     )
-  }
+  )
+
+  x <- lme4::glmer(vs ~ mpg + (1 | cyl), data = mtcars, family = "binomial")
+  expect_identical(
+    as.character(report_performance(x)),
+    paste(
+      "The model's total explanatory power is substantial (conditional R2 = 0.59) and the",
+      "part related to the fixed effects alone (marginal R2) is of 0.13"
+    )
+  )
+  expect_identical(
+    as.character(summary(report_performance(x))),
+    paste(
+      "The model's total explanatory power is substantial (conditional R2 = 0.59) and the",
+      "part related to the fixed effects alone (marginal R2) is of 0.13"
+    )
+  )
 
   # Bayesian
-  if (requiet("rstanarm")) {
-    x <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 1000, seed = 333)
-    expect_snapshot(
-      variant = "windows",
-      report_performance(x)
-    )
-    expect_snapshot(
-      variant = "windows",
-      summary(report_performance(x))
-    )
+  skip_if_not_or_load_if_installed("rstanarm")
 
-    x <- stan_glm(vs ~ disp, data = mtcars, family = "binomial", refresh = 0, iter = 1000, seed = 333)
-    expect_snapshot(
-      variant = "windows",
-      report_performance(x)
-    )
-    expect_snapshot(
-      variant = "windows",
-      summary(report_performance(x))
-    )
+  x <- stan_glm(Sepal.Length ~ Species, data = iris, refresh = 0, iter = 1000, seed = 333)
+  expect_snapshot(
+    variant = "windows",
+    report_performance(x)
+  )
+  expect_snapshot(
+    variant = "windows",
+    summary(report_performance(x))
+  )
 
-    x <- stan_lmer(Sepal.Length ~ Petal.Length + (1 | Species), data = iris, refresh = 0, iter = 1000, seed = 333)
-    expect_snapshot(
-      variant = "windows",
-      report_performance(x)
-    )
-    expect_snapshot(
-      variant = "windows",
-      summary(report_performance(x))
-    )
-  }
+  x <- stan_glm(vs ~ disp, data = mtcars, family = "binomial", refresh = 0, iter = 1000, seed = 333)
+  expect_snapshot(
+    variant = "windows",
+    report_performance(x)
+  )
+  expect_snapshot(
+    variant = "windows",
+    summary(report_performance(x))
+  )
+
+  x <- stan_lmer(Sepal.Length ~ Petal.Length + (1 | Species), data = iris, refresh = 0, iter = 1000, seed = 333)
+  expect_snapshot(
+    variant = "windows",
+    report_performance(x)
+  )
+  expect_snapshot(
+    variant = "windows",
+    summary(report_performance(x))
+  )
 })


### PR DESCRIPTION
Addresses easystats/easystats#350 for report

---

As a side note, I've noticed many report test files are filled with `set.seed(123)` at almost single line while it seems almost never necessary (e.g., unless dealing with actual random values like in stan)... is it ok to remove those?