### PR TITLE
# report 0.5.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: report
 Title: Automated Reporting of Results and Statistical Models
-Version: 0.5.6
+Version: 0.5.7
 Authors@R:
     c(person(given = "Dominique",
              family = "Makowski",
@@ -55,13 +55,10 @@ Imports:
     insight (>= 0.19.1),
     parameters (>= 0.20.0),
     performance (>= 0.9.2),
-    datawizard (>= 0.7.0),
+    datawizard (>= 0.6.5),
     stats,
     tools,
     utils
-Remotes:
-    easystats/effectsize,
-    easystats/datawizard
 Suggests:
     brms,
     ivreg,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# report 0.5.7
+
+Hotfix for CRAN reverse dependency compatibility.
+
 # report 0.5.6
 
 Breaking Changes

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,7 @@
+## R CMD check results report 0.5.7
+
+0 errors | 0 warnings | 0 note
+
 ## R CMD check results report 0.5.6
 
 0 errors | 0 warnings | 1 note


### PR DESCRIPTION
Hotfix for easystats CRAN reverse dependency compatibility. Had to create a PR because it didn't allow me to push to the main branch (protected branch).