### PR TITLE
Add ^pkgdown$ to .Rbuildignore to get rid of note

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,6 +10,7 @@
 ^revdep$
 ^codecov\.yml$
 ^_pkgdown\.yml$
+^pkgdown$
 ^data-raw$
 ^\.httr-oauth$
 ^CRAN-RELEASE$


### PR DESCRIPTION
Add ^pkgdown$ to .Rbuildignore to get rid of note. Could not commit directly on GH for this tiny change because of the protected branch, and also could not find how to temporarily deprotect the branch because there is no setting button on this repo!