### PR TITLE
\162\Fix_Unstable_Group_by_Behaviour

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -12,6 +12,6 @@ linters: linters_with_defaults(
     todo_comment_linter = NULL,
     undesirable_function_linter(c("mapply" = NA, "sapply" = NA, "setwd" = NA)),
     undesirable_operator_linter = NULL,
-    unnecessary_concatenation_linter(allow_single_expression = FALSE),
+    unneeded_concatenation_linter(allow_single_expression = FALSE),
     defaults = linters_with_tags(tags = NULL)
   )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,12 +37,12 @@ Authors@R:
              family = "Siegel",
              role = "ctb",
              email = "mutlusun@users.noreply.github.com",
-             comment = c(ORCID = "0000-0002-6021-804X"))),
+             comment = c(ORCID = "0000-0002-6021-804X")),
      person(given = "Camden",
             family = "Bock",
             role = "ctb",
             email = "camden.bock@maine.edu",
-            comment = c(ORCID = "0000-0002-3907-7748"))
+            comment = c(ORCID = "0000-0002-3907-7748")))
 Maintainer: Rémi Thériault <remi.theriault@mail.mcgill.ca>
 Description: The aim of the 'report' package is to bridge the gap between
     R’s output and the formatted results contained in your manuscript.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,12 @@ Authors@R:
              family = "Siegel",
              role = "ctb",
              email = "mutlusun@users.noreply.github.com",
-             comment = c(ORCID = "0000-0002-6021-804X")))
+             comment = c(ORCID = "0000-0002-6021-804X"))),
+     person(given = "Camden",
+            family = "Bock",
+            role = "ctb",
+            email = "camden.bock@maine.edu",
+            comment = c(ORCID = "0000-0002-3907-7748"))
 Maintainer: Rémi Thériault <remi.theriault@mail.mcgill.ca>
 Description: The aim of the 'report' package is to bridge the gap between
     R’s output and the formatted results contained in your manuscript.

--- a/R/report.data.frame.R
+++ b/R/report.data.frame.R
@@ -380,17 +380,17 @@ report_table.grouped_df <- function(x,
 
     current_table_full$Group <- group
     # table_full <- rbind(table_full, current_table_full)
-    if(!length(table_full) == 0){
+    if (!length(table_full) == 0) {
       table_full <- merge(table_full, current_table_full, all = TRUE, sort = FALSE)
-    }else{
+    } else {
       table_full <- current_table_full
     }
     current_table <- summary(current_table_full)
     current_table$Group <- group
     # table <- rbind(table, current_table)
-    if(!length(table) == 0){
+    if (!length(table) == 0) {
       table <- merge(table, current_table, all = TRUE, sort = FALSE)
-    }else{
+    } else {
       table <- current_table
     }
   }

--- a/R/report.data.frame.R
+++ b/R/report.data.frame.R
@@ -379,15 +379,14 @@ report_table.grouped_df <- function(x,
     )
 
     current_table_full$Group <- group
-    # table_full <- rbind(table_full, current_table_full)
     if (!length(table_full) == 0) {
       table_full <- merge(table_full, current_table_full, all = TRUE, sort = FALSE)
     } else {
       table_full <- current_table_full
     }
+    
     current_table <- summary(current_table_full)
     current_table$Group <- group
-    # table <- rbind(table, current_table)
     if (!length(table) == 0) {
       table <- merge(table, current_table, all = TRUE, sort = FALSE)
     } else {

--- a/R/report.data.frame.R
+++ b/R/report.data.frame.R
@@ -384,7 +384,7 @@ report_table.grouped_df <- function(x,
     } else {
       table_full <- current_table_full
     }
-    
+
     current_table <- summary(current_table_full)
     current_table$Group <- group
     if (!length(table) == 0) {

--- a/R/report.data.frame.R
+++ b/R/report.data.frame.R
@@ -380,11 +380,19 @@ report_table.grouped_df <- function(x,
 
     current_table_full$Group <- group
     # table_full <- rbind(table_full, current_table_full)
-    table_full <- merge(table_full, current_table_full, all = TRUE, sort = FALSE)
+    if(!length(table_full) == 0){
+      table_full <- merge(table_full, current_table_full, all = TRUE, sort = FALSE)
+    }else{
+      table_full <- current_table_full
+    }
     current_table <- summary(current_table_full)
     current_table$Group <- group
     # table <- rbind(table, current_table)
-    table <- merge(table, current_table, all = TRUE, sort = FALSE)
+    if(!length(table) == 0){
+      table <- merge(table, current_table, all = TRUE, sort = FALSE)
+    }else{
+      table <- current_table
+    }
   }
 
   table <- datawizard::data_reorder(table, "Group")

--- a/tests/testthat/test-report.data.frame.R
+++ b/tests/testthat/test-report.data.frame.R
@@ -59,7 +59,7 @@ test_that("report.data.frame", {
   expect_equal(mean(as.data.frame(r)$n_Obs), 107, tolerance = 0.01)
 
   r <- report(dplyr::group_by(iris, Species))
-  expect_equal(nrow(as.data.frame(r)), 8, tolerance = 0)
+  expect_equal(nrow(as.data.frame(r)), 12, tolerance = 0)
   expect_equal(mean(as.data.frame(r)$n_Obs), 50, tolerance = 0)
 
   expect_snapshot(variant = "windows", r)


### PR DESCRIPTION
Fixes #162 and Fixes #246 

# Description

This PR fixes the bug in #162, where the first factor group of a grouped data frame is neglected in the output of report_table.

# Proposed Changes

I added a conditional in the `report_table.grouped_df` that only uses the `merge` function when merging into a non-empty dataframe.

## Details

When I add  `print(table)` inside the for loop of  `report_table.grouped_df` of `report.data.frame` line 390 and provide `iris %>% group_by(Species)`

I get:

```r
[1] Variable  Mean      SD        Min       Max       n_Missing Group    
<0 rows> (or 0-length row.names)
      Variable  Mean        SD Min Max n_Missing      Group
1 Sepal.Length 5.936 0.5161711 4.9 7.0         0 versicolor
2  Sepal.Width 2.770 0.3137983 2.0 3.4         0 versicolor
3 Petal.Length 4.260 0.4699110 3.0 5.1         0 versicolor
4  Petal.Width 1.326 0.1977527 1.0 1.8         0 versicolor
      Variable  Mean        SD Min Max n_Missing      Group
1 Sepal.Length 5.936 0.5161711 4.9 7.0         0 versicolor
2  Sepal.Width 2.770 0.3137983 2.0 3.4         0 versicolor
3 Petal.Length 4.260 0.4699110 3.0 5.1         0 versicolor
4  Petal.Width 1.326 0.1977527 1.0 1.8         0 versicolor
5 Sepal.Length 6.588 0.6358796 4.9 7.9         0  virginica
6  Sepal.Width 2.974 0.3224966 2.2 3.8         0  virginica
7 Petal.Length 5.552 0.5518947 4.5 6.9         0  virginica
8  Petal.Width 2.026 0.2746501 1.4 2.5         0  virginica
```

Showing a zero-length table on the first iteration, and loosing that group from the output

```r
Group      |     Variable | n_Obs | Mean |   SD | Median |  MAD |  Min |  Max | Skewness | Kurtosis | n_Missing
---------------------------------------------------------------------------------------------------------------
versicolor | Sepal.Length |    50 | 5.94 | 0.52 |   5.90 | 0.52 | 4.90 | 7.00 |     0.11 |    -0.53 |         0
versicolor |  Sepal.Width |    50 | 2.77 | 0.31 |   2.80 | 0.30 | 2.00 | 3.40 |    -0.36 |    -0.37 |         0
versicolor | Petal.Length |    50 | 4.26 | 0.47 |   4.35 | 0.52 | 3.00 | 5.10 |    -0.61 |     0.05 |         0
versicolor |  Petal.Width |    50 | 1.33 | 0.20 |   1.30 | 0.22 | 1.00 | 1.80 |    -0.03 |    -0.41 |         0
virginica  | Sepal.Length |    50 | 6.59 | 0.64 |   6.50 | 0.59 | 4.90 | 7.90 |     0.12 |     0.03 |         0
virginica  |  Sepal.Width |    50 | 2.97 | 0.32 |   3.00 | 0.30 | 2.20 | 3.80 |     0.37 |     0.71 |         0
virginica  | Petal.Length |    50 | 5.55 | 0.55 |   5.55 | 0.67 | 4.50 | 6.90 |     0.55 |    -0.15 |         0
virginica  |  Petal.Width |    50 | 2.03 | 0.27 |   2.00 | 0.30 | 1.40 | 2.50 |    -0.13 |    -0.60 |         0
```

If I instead run `print(current_table)`, I find three tables as expected

```r
Variable     | Mean |   SD |  Min |  Max | n_Missing |  Group
-------------------------------------------------------------
Sepal.Length | 5.01 | 0.35 | 4.30 | 5.80 |         0 | setosa
Sepal.Width  | 3.43 | 0.38 | 2.30 | 4.40 |         0 | setosa
Petal.Length | 1.46 | 0.17 | 1.00 | 1.90 |         0 | setosa
Petal.Width  | 0.25 | 0.11 | 0.10 | 0.60 |         0 | setosa
Variable     | Mean |   SD |  Min |  Max | n_Missing |      Group
-----------------------------------------------------------------
Sepal.Length | 5.94 | 0.52 | 4.90 | 7.00 |         0 | versicolor
Sepal.Width  | 2.77 | 0.31 | 2.00 | 3.40 |         0 | versicolor
Petal.Length | 4.26 | 0.47 | 3.00 | 5.10 |         0 | versicolor
Petal.Width  | 1.33 | 0.20 | 1.00 | 1.80 |         0 | versicolor
Variable     | Mean |   SD |  Min |  Max | n_Missing |     Group
----------------------------------------------------------------
Sepal.Length | 6.59 | 0.64 | 4.90 | 7.90 |         0 | virginica
Sepal.Width  | 2.97 | 0.32 | 2.20 | 3.80 |         0 | virginica
Petal.Length | 5.55 | 0.55 | 4.50 | 6.90 |         0 | virginica
Petal.Width  | 2.03 | 0.27 | 1.40 | 2.50 |         0 | virginica
```

but of course, the same output.

Similar problem for `table_full`

```r
 [1] Variable  n_Obs     Mean      SD        Median    MAD       Min       Max       Skewness  Kurtosis 
[11] n_Missing Group    
<0 rows> (or 0-length row.names)
      Variable n_Obs  Mean        SD Median     MAD Min Max   Skewness   Kurtosis n_Missing      Group
1 Sepal.Length    50 5.936 0.5161711   5.90 0.51891 4.9 7.0  0.1053776 -0.5330095         0 versicolor
2  Sepal.Width    50 2.770 0.3137983   2.80 0.29652 2.0 3.4 -0.3628448 -0.3662374         0 versicolor
3 Petal.Length    50 4.260 0.4699110   4.35 0.51891 3.0 5.1 -0.6065077  0.0479033         0 versicolor
4  Petal.Width    50 1.326 0.1977527   1.30 0.22239 1.0 1.8 -0.0311796 -0.4100592         0 versicolor
      Variable n_Obs  Mean        SD Median     MAD Min Max   Skewness    Kurtosis n_Missing      Group
1 Sepal.Length    50 5.936 0.5161711   5.90 0.51891 4.9 7.0  0.1053776 -0.53300954         0 versicolor
2  Sepal.Width    50 2.770 0.3137983   2.80 0.29652 2.0 3.4 -0.3628448 -0.36623736         0 versicolor
3 Petal.Length    50 4.260 0.4699110   4.35 0.51891 3.0 5.1 -0.6065077  0.04790330         0 versicolor
4  Petal.Width    50 1.326 0.1977527   1.30 0.22239 1.0 1.8 -0.0311796 -0.41005924         0 versicolor
5 Sepal.Length    50 6.588 0.6358796   6.50 0.59304 4.9 7.9  0.1180151  0.03290442         0  virginica
6  Sepal.Width    50 2.974 0.3224966   3.00 0.29652 2.2 3.8  0.3659491  0.70607051         0  virginica
7 Petal.Length    50 5.552 0.5518947   5.55 0.66717 4.5 6.9  0.5494446 -0.15377856         0  virginica
8  Petal.Width    50 2.026 0.2746501   2.00 0.29652 1.4 2.5 -0.1294769 -0.60226448         0  virginica
> 
```

Two very crude modifications get the expected result. I'm not sure if there is a better way to handle `merge` in this case. 

I wonder if merge does not include new rows but adopts new columns when a non-empty data frame merges with an empty data frame?


```r
    if(!length(table_full) == 0){
      table_full <- merge(table_full, current_table_full, all = TRUE, sort = FALSE)
    }else{
      table_full <- current_table_full
    }
 ```
```r
    if(!length(table) == 0){
      table <- merge(table, current_table, all = TRUE, sort = FALSE)
    }else{
      table <- current_table
    }
```
 
 Produces table_full:
 ```r
 Variable     | n_Obs | Mean |   SD | Median |  MAD |  Min |  Max | Skewness | Kurtosis | n_Missing |  Group
-----------------------------------------------------------------------------------------------------------
Sepal.Length |    50 | 5.01 | 0.35 |   5.00 | 0.30 | 4.30 | 5.80 |     0.12 |    -0.25 |         0 | setosa
Sepal.Width  |    50 | 3.43 | 0.38 |   3.40 | 0.37 | 2.30 | 4.40 |     0.04 |     0.95 |         0 | setosa
Petal.Length |    50 | 1.46 | 0.17 |   1.50 | 0.15 | 1.00 | 1.90 |     0.11 |     1.02 |         0 | setosa
Petal.Width  |    50 | 0.25 | 0.11 |   0.20 | 0.00 | 0.10 | 0.60 |     1.25 |     1.72 |         0 | setosa
      Variable n_Obs  Mean        SD Median     MAD Min Max    Skewness   Kurtosis n_Missing      Group
1 Sepal.Length    50 5.006 0.3524897   5.00 0.29652 4.3 5.8  0.12008699 -0.2526888         0     setosa
2  Sepal.Width    50 3.428 0.3790644   3.40 0.37065 2.3 4.4  0.04116652  0.9547033         0     setosa
3 Petal.Length    50 1.462 0.1736640   1.50 0.14826 1.0 1.9  0.10639390  1.0215761         0     setosa
4  Petal.Width    50 0.246 0.1053856   0.20 0.00000 0.1 0.6  1.25386137  1.7191302         0     setosa
5 Sepal.Length    50 5.936 0.5161711   5.90 0.51891 4.9 7.0  0.10537762 -0.5330095         0 versicolor
6  Sepal.Width    50 2.770 0.3137983   2.80 0.29652 2.0 3.4 -0.36284484 -0.3662374         0 versicolor
7 Petal.Length    50 4.260 0.4699110   4.35 0.51891 3.0 5.1 -0.60650769  0.0479033         0 versicolor
8  Petal.Width    50 1.326 0.1977527   1.30 0.22239 1.0 1.8 -0.03117960 -0.4100592         0 versicolor
       Variable n_Obs  Mean        SD Median     MAD Min Max    Skewness    Kurtosis n_Missing      Group
1  Sepal.Length    50 5.006 0.3524897   5.00 0.29652 4.3 5.8  0.12008699 -0.25268880         0     setosa
2   Sepal.Width    50 3.428 0.3790644   3.40 0.37065 2.3 4.4  0.04116652  0.95470326         0     setosa
3  Petal.Length    50 1.462 0.1736640   1.50 0.14826 1.0 1.9  0.10639390  1.02157611         0     setosa
4   Petal.Width    50 0.246 0.1053856   0.20 0.00000 0.1 0.6  1.25386137  1.71913025         0     setosa
5  Sepal.Length    50 5.936 0.5161711   5.90 0.51891 4.9 7.0  0.10537762 -0.53300954         0 versicolor
6   Sepal.Width    50 2.770 0.3137983   2.80 0.29652 2.0 3.4 -0.36284484 -0.36623736         0 versicolor
7  Petal.Length    50 4.260 0.4699110   4.35 0.51891 3.0 5.1 -0.60650769  0.04790330         0 versicolor
8   Petal.Width    50 1.326 0.1977527   1.30 0.22239 1.0 1.8 -0.03117960 -0.41005924         0 versicolor
9  Sepal.Length    50 6.588 0.6358796   6.50 0.59304 4.9 7.9  0.11801512  0.03290442         0  virginica
10  Sepal.Width    50 2.974 0.3224966   3.00 0.29652 2.2 3.8  0.36594907  0.70607051         0  virginica
11 Petal.Length    50 5.552 0.5518947   5.55 0.66717 4.5 6.9  0.54944459 -0.15377856         0  virginica
12  Petal.Width    50 2.026 0.2746501   2.00 0.29652 1.4 2.5 -0.12947693 -0.60226448         0  virginica
 ```

and 

```r
Variable     | Mean |   SD |  Min |  Max | n_Missing |  Group
-------------------------------------------------------------
Sepal.Length | 5.01 | 0.35 | 4.30 | 5.80 |         0 | setosa
Sepal.Width  | 3.43 | 0.38 | 2.30 | 4.40 |         0 | setosa
Petal.Length | 1.46 | 0.17 | 1.00 | 1.90 |         0 | setosa
Petal.Width  | 0.25 | 0.11 | 0.10 | 0.60 |         0 | setosa
      Variable  Mean        SD Min Max n_Missing      Group
1 Sepal.Length 5.006 0.3524897 4.3 5.8         0     setosa
2  Sepal.Width 3.428 0.3790644 2.3 4.4         0     setosa
3 Petal.Length 1.462 0.1736640 1.0 1.9         0     setosa
4  Petal.Width 0.246 0.1053856 0.1 0.6         0     setosa
5 Sepal.Length 5.936 0.5161711 4.9 7.0         0 versicolor
6  Sepal.Width 2.770 0.3137983 2.0 3.4         0 versicolor
7 Petal.Length 4.260 0.4699110 3.0 5.1         0 versicolor
8  Petal.Width 1.326 0.1977527 1.0 1.8         0 versicolor
       Variable  Mean        SD Min Max n_Missing      Group
1  Sepal.Length 5.006 0.3524897 4.3 5.8         0     setosa
2   Sepal.Width 3.428 0.3790644 2.3 4.4         0     setosa
3  Petal.Length 1.462 0.1736640 1.0 1.9         0     setosa
4   Petal.Width 0.246 0.1053856 0.1 0.6         0     setosa
5  Sepal.Length 5.936 0.5161711 4.9 7.0         0 versicolor
6   Sepal.Width 2.770 0.3137983 2.0 3.4         0 versicolor
7  Petal.Length 4.260 0.4699110 3.0 5.1         0 versicolor
8   Petal.Width 1.326 0.1977527 1.0 1.8         0 versicolor
9  Sepal.Length 6.588 0.6358796 4.9 7.9         0  virginica
10  Sepal.Width 2.974 0.3224966 2.2 3.8         0  virginica
11 Petal.Length 5.552 0.5518947 4.5 6.9         0  virginica
12  Petal.Width 2.026 0.2746501 1.4 2.5         0  virginica
```

With resulting output as expected

```r
Group      |     Variable | n_Obs | Mean |   SD | Median |  MAD |  Min |  Max | Skewness | Kurtosis | n_Missing
---------------------------------------------------------------------------------------------------------------
setosa     | Sepal.Length |    50 | 5.01 | 0.35 |   5.00 | 0.30 | 4.30 | 5.80 |     0.12 |    -0.25 |         0
setosa     |  Sepal.Width |    50 | 3.43 | 0.38 |   3.40 | 0.37 | 2.30 | 4.40 |     0.04 |     0.95 |         0
setosa     | Petal.Length |    50 | 1.46 | 0.17 |   1.50 | 0.15 | 1.00 | 1.90 |     0.11 |     1.02 |         0
setosa     |  Petal.Width |    50 | 0.25 | 0.11 |   0.20 | 0.00 | 0.10 | 0.60 |     1.25 |     1.72 |         0
versicolor | Sepal.Length |    50 | 5.94 | 0.52 |   5.90 | 0.52 | 4.90 | 7.00 |     0.11 |    -0.53 |         0
versicolor |  Sepal.Width |    50 | 2.77 | 0.31 |   2.80 | 0.30 | 2.00 | 3.40 |    -0.36 |    -0.37 |         0
versicolor | Petal.Length |    50 | 4.26 | 0.47 |   4.35 | 0.52 | 3.00 | 5.10 |    -0.61 |     0.05 |         0
versicolor |  Petal.Width |    50 | 1.33 | 0.20 |   1.30 | 0.22 | 1.00 | 1.80 |    -0.03 |    -0.41 |         0
virginica  | Sepal.Length |    50 | 6.59 | 0.64 |   6.50 | 0.59 | 4.90 | 7.90 |     0.12 |     0.03 |         0
virginica  |  Sepal.Width |    50 | 2.97 | 0.32 |   3.00 | 0.30 | 2.20 | 3.80 |     0.37 |     0.71 |         0
virginica  | Petal.Length |    50 | 5.55 | 0.55 |   5.55 | 0.67 | 4.50 | 6.90 |     0.55 |    -0.15 |         0
virginica  |  Petal.Width |    50 | 2.03 | 0.27 |   2.00 | 0.30 | 1.40 | 2.50 |    -0.13 |    -0.60 |         0
```