### PR TITLE
Address Gender vs Sex mismatch in report_participants

### DIFF
--- a/R/report_participants.R
+++ b/R/report_participants.R
@@ -10,7 +10,7 @@
 #'   you can specify other characters here as well (e.g., `"Intersex"`), but
 #'   the function will group all individuals in those groups as `"Other"`.
 #' @param gender The name of the column containing the gender of the
-#'   classes should be one of `c("Man", "M", "Male", Woman", "W", F",
+#'   classes should be one of `c("Man", "M", "Male", Woman", "W", "F",
 #'   "Female", Non-Binary", "N")`. Note that you can specify other characters
 #'   here as well (e.g., `"Gender Fluid"`), but the function will group all
 #'   individuals in those groups as `"Non-Binary"`.

--- a/R/report_participants.R
+++ b/R/report_participants.R
@@ -355,7 +355,7 @@ report_participants <- function(data,
   }
 
   genders_woman <- c(
-    "woman", "w", "female", "women", "girl",
+    "woman", "w", "female", "f", "women", "girl",
     "lady", "miss", "madam", "dame", "lass"
   )
   genders_man <- c(

--- a/man/report_participants.Rd
+++ b/man/report_participants.Rd
@@ -32,7 +32,7 @@ you can specify other characters here as well (e.g., \code{"Intersex"}), but
 the function will group all individuals in those groups as \code{"Other"}.}
 
 \item{gender}{The name of the column containing the gender of the
-classes should be one of \verb{c("Man", "M", "Male", Woman", "W", F", "Female", Non-Binary", "N")}. Note that you can specify other characters
+classes should be one of \verb{c("Man", "M", "Male", Woman", "W", "F", "Female", Non-Binary", "N")}. Note that you can specify other characters
 here as well (e.g., \code{"Gender Fluid"}), but the function will group all
 individuals in those groups as \code{"Non-Binary"}.}
 


### PR DESCRIPTION
Addresses #437 

As stated in the header:

# @param gender The name of the column containing the gender of the
#'   classes should be one of `c("Man", "M", "Male", Woman", "W", **"F"**,
#'   "Female", Non-Binary"